### PR TITLE
Fix #41, Remove 'return;' from last line of void functions.

### DIFF
--- a/docs/dox_src/cfs_lc.dox
+++ b/docs/dox_src/cfs_lc.dox
@@ -230,7 +230,7 @@
   #CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE parameter. When considering how many watchpoints and
   actionpoints are needed, keep in mind the the entire WDT is sequentially searched
   whenever a message that may contain watchpoints is received. Likewise the entire
-  ADT will be processed whenever a #LC_SAMPLE_AP_MID message is recieved. While it
+  ADT will be processed whenever a #LC_SAMPLE_AP_MID message is received. While it
   is desirable to leave unused entries in both tables for later updates, large tables
   will increase search time which may be undesirable depending on the telemetry and 
   actionpoint sample rates required. LC defines the performance ID #LC_WDT_SEARCH_PERF_ID
@@ -429,7 +429,7 @@
      #LC_WATCH_STALE is an initialization value for the Watchpoint
      Results Table. If a watchpoint has this WatchResult then the watchpoint
      is unused (the DataType in the WDT is set to #LC_WATCH_NOT_USED) or a
-     message that contains the watchpoint has not yet been recieved by LC and 
+     message that contains the watchpoint has not yet been received by LC and 
      evaluated.
   </I>
 
@@ -526,7 +526,7 @@
         #LC_ACTION_NOT_USED).
         
      2) An actionpoint sample request (#LC_SAMPLE_AP_MID) targeting the AP has not 
-        yet been recieved by LC so the AP has not yet been evaluated.
+        yet been received by LC so the AP has not yet been evaluated.
           
      3) One or more of the watchpoints that this AP depends on (as defined by
         the RPN expression) has a current WatchResult of #LC_WATCH_STALE

--- a/fsw/src/lc_action.c
+++ b/fsw/src/lc_action.c
@@ -78,9 +78,6 @@ void LC_SampleAPs(uint16 StartIndex, uint16 EndIndex)
             LC_SampleSingleAP(TableIndex);
         }
     }
-
-    return;
-
 } /* end LC_SampleAP */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -268,9 +265,6 @@ void LC_SampleSingleAP(uint16 APNumber)
         }
 
     } /* end CurrentAPState if */
-
-    return;
-
 } /* end LC_SampleSingleAP */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -198,9 +198,6 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr)
             }
         }
     }
-
-    return;
-
 } /* end LC_SampleAPReq */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -509,9 +506,6 @@ void LC_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(LC_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command: Version %d.%d.%d.%d",
                           LC_MAJOR_VERSION, LC_MINOR_VERSION, LC_REVISION, LC_MISSION_REV);
     }
-
-    return;
-
 } /* end LC_NoopCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -532,9 +526,6 @@ void LC_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
 
         CFE_EVS_SendEvent(LC_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
     }
-
-    return;
-
 } /* end LC_ResetCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -551,9 +542,6 @@ void LC_ResetCounters(void)
     LC_AppData.MonitoredMsgCount   = 0;
     LC_AppData.RTSExecCount        = 0;
     LC_AppData.PassiveRTSExecCount = 0;
-
-    return;
-
 } /* end LC_ResetCounters */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -593,9 +581,6 @@ void LC_SetLCStateCmd(const CFE_SB_Buffer_t *BufPtr)
                 break;
         }
     }
-
-    return;
-
 } /* end LC_SetLCStateCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -724,9 +709,6 @@ void LC_SetAPStateCmd(const CFE_SB_Buffer_t *BufPtr)
         } /* end ValidState if */
 
     } /* end LC_VerifyMsgLength if */
-
-    return;
-
 } /* end LC_SetAPStateCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -792,9 +774,6 @@ void LC_SetAPPermOffCmd(const CFE_SB_Buffer_t *BufPtr)
         } /* end CmdPtr -> APNumber else */
 
     } /* end LC_VerifyMsgLength if */
-
-    return;
-
 } /* end LC_SetAPPermOffCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -839,9 +818,6 @@ void LC_ResetAPStatsCmd(const CFE_SB_Buffer_t *BufPtr)
                               CmdPtr->APNumber);
         }
     }
-
-    return;
-
 } /* end LC_ResetAPStatsCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -872,9 +848,6 @@ void LC_ResetResultsAP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd)
         LC_OperData.ARTPtr[TableIndex].CumulativeRTSExecCount  = 0;
         LC_OperData.ARTPtr[TableIndex].CumulativeEventMsgsSent = 0;
     }
-
-    return;
-
 } /* end LC_ResetResultsAP */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -919,9 +892,6 @@ void LC_ResetWPStatsCmd(const CFE_SB_Buffer_t *BufPtr)
                               CmdPtr->WPNumber);
         }
     }
-
-    return;
-
 } /* end LC_ResetWPStatsCmd */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -956,9 +926,6 @@ void LC_ResetResultsWP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd)
         LC_OperData.WRTPtr[TableIndex].LastTrueToFalse.Timestamp.Seconds    = 0;
         LC_OperData.WRTPtr[TableIndex].LastTrueToFalse.Timestamp.Subseconds = 0;
     }
-
-    return;
-
 } /* end LC_ResetResultsWP */
 
 /************************/

--- a/fsw/src/lc_custom.c
+++ b/fsw/src/lc_custom.c
@@ -52,9 +52,6 @@ void LC_ExecuteRTS(uint16 RTSId)
     RTSRequest.RTSId = RTSId;
 
     CFE_SB_TransmitMsg(&RTSRequest.CmdHeader.Msg, true);
-
-    return;
-
 } /* end LC_ExecuteRTS */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -131,9 +131,6 @@ void LC_CreateHashTable(void)
             LastMessageID = MessageID;
         }
     }
-
-    return;
-
 } /* End of LC_CreateHashTable() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -323,9 +320,6 @@ void LC_CheckMsgForWPs(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID));
         }
     }
-
-    return;
-
 } /* end LC_CheckMsgForWPs */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -430,9 +424,6 @@ void LC_ProcessWP(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr, CFE_TIME_Sys
         }
 
     } /* end SizedDataValid if */
-
-    return;
-
 } /* end LC_ProcessWP */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #41
Removes all cases of redundant "return;" statements on the last line of void functions.
Corrected a few typos in the comments that were noticed along the way.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 