### PR TITLE
Fix #43, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/lc_action.c
+++ b/fsw/src/lc_action.c
@@ -80,8 +80,7 @@ void LC_SampleAPs(uint16 StartIndex, uint16 EndIndex)
     }
 
     return;
-
-} /* end LC_SampleAP */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -270,8 +269,7 @@ void LC_SampleSingleAP(uint16 APNumber)
     } /* end CurrentAPState if */
 
     return;
-
-} /* end LC_SampleSingleAP */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -474,8 +472,7 @@ uint8 LC_EvaluateRPN(uint16 APNumber)
     }
 
     return (EvalResult);
-
-} /* end LC_EvaluateRPN */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -604,8 +601,7 @@ int32 LC_ValidateADT(void *TableData)
                       (int)UnusedCount);
 
     return (TableResult);
-
-} /* end LC_ValidateADT */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -704,9 +700,4 @@ int32 LC_ValidateRPN(const uint16 *RPNPtr, int32 *IndexValue, int32 *StackDepthV
     }
 
     return (Result);
-
-} /* end LC_ValidateRPN */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/lc_app.c
+++ b/fsw/src/lc_app.c
@@ -170,8 +170,7 @@ void LC_AppMain(void)
     ** Exit the application
     */
     CFE_ES_ExitApp(RunStatus);
-
-} /* end LC_AppMain */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -221,8 +220,7 @@ int32 LC_AppInit(void)
     }
 
     return (Status);
-
-} /* end LC_AppInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -250,8 +248,7 @@ int32 LC_EvsInit(void)
     }
 
     return (Status);
-
-} /* end LC_EvsInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -320,8 +317,7 @@ int32 LC_SbInit(void)
     }
 
     return (Status);
-
-} /* end LC_SbInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -489,8 +485,7 @@ int32 LC_TableInit(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* LC_TableInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -566,8 +561,7 @@ int32 LC_CreateResultTables(void)
     }
 
     return (Result);
-
-} /* LC_CreateResultTables() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -723,8 +717,7 @@ int32 LC_CreateDefinitionTables(void)
     }
 
     return (Result);
-
-} /* LC_CreateDefinitionTables() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -851,8 +844,7 @@ int32 LC_CreateTaskCDS(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* LC_CreateTaskCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -971,9 +963,4 @@ int32 LC_LoadDefaultTables(void)
     }
 
     return (Result);
-
-} /* LC_LoadDefaultTables() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/lc_app.h
+++ b/fsw/src/lc_app.h
@@ -120,7 +120,6 @@ typedef struct LC_WListTag
 
     uint16 WatchIndex; /**< \brief Watchpoint table index   */
     uint16 Spare;      /**< \brief Structure alignment pad  */
-
 } LC_WatchPtList_t;
 
 /** \brief Linked list of MessageID's with same hash function result */
@@ -132,7 +131,6 @@ typedef struct LC_MListTag
     uint16         Spare;     /**< \brief Structure alignment pad  */
 
     LC_WatchPtList_t *WatchPtList; /**< \brief Watchpoint list for this MessageID */
-
 } LC_MessageList_t;
 
 /************************************************************************

--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -123,8 +123,7 @@ int32 LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
     } /* end MessageID switch */
 
     return (Status);
-
-} /* End LC_AppPipe */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -200,8 +199,7 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_SampleAPReq */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -487,8 +485,7 @@ int32 LC_HousekeepingReq(const CFE_MSG_CommandHeader_t *MsgPtr)
     Result = LC_PerformMaintenance();
 
     return Result;
-
-} /* end LC_HousekeepingReq */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -511,8 +508,7 @@ void LC_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_NoopCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -534,8 +530,7 @@ void LC_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_ResetCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -553,8 +548,7 @@ void LC_ResetCounters(void)
     LC_AppData.PassiveRTSExecCount = 0;
 
     return;
-
-} /* end LC_ResetCounters */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -595,8 +589,7 @@ void LC_SetLCStateCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_SetLCStateCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -726,8 +719,7 @@ void LC_SetAPStateCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end LC_VerifyMsgLength if */
 
     return;
-
-} /* end LC_SetAPStateCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -794,8 +786,7 @@ void LC_SetAPPermOffCmd(const CFE_SB_Buffer_t *BufPtr)
     } /* end LC_VerifyMsgLength if */
 
     return;
-
-} /* end LC_SetAPPermOffCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -841,8 +832,7 @@ void LC_ResetAPStatsCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_ResetAPStatsCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -874,8 +864,7 @@ void LC_ResetResultsAP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd)
     }
 
     return;
-
-} /* end LC_ResetResultsAP */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -921,8 +910,7 @@ void LC_ResetWPStatsCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_ResetWPStatsCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -958,9 +946,4 @@ void LC_ResetResultsWP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd)
     }
 
     return;
-
-} /* end LC_ResetResultsWP */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/lc_custom.c
+++ b/fsw/src/lc_custom.c
@@ -54,8 +54,7 @@ void LC_ExecuteRTS(uint16 RTSId)
     CFE_SB_TransmitMsg(&RTSRequest.CmdHeader.Msg, true);
 
     return;
-
-} /* end LC_ExecuteRTS */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -91,9 +90,4 @@ uint8 LC_CustomFunction(uint16 WatchIndex, uint32 ProcessedWPData, const CFE_SB_
     } /* end WatchIndex switch */
 
     return (EvalResult);
-
-} /* end LC_CustomFunction */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/lc_tbl.h
+++ b/fsw/src/lc_tbl.h
@@ -131,7 +131,6 @@ typedef struct
     uint8 Padding[3]; /**< \brief Structure padding */
 
     CFE_TIME_SysTime_t Timestamp; /**< \brief Timstamp when the transition was detected    */
-
 } LC_WRTTransition_t;
 
 /**
@@ -157,7 +156,6 @@ typedef struct
                                                     has evaluated to TRUE                  */
     LC_WRTTransition_t LastFalseToTrue; /**< \brief Last transition from FALSE to TRUE     */
     LC_WRTTransition_t LastTrueToFalse; /**< \brief Last transition from TRUE to FALSE     */
-
 } LC_WRTEntry_t;
 
 /**

--- a/fsw/src/lc_utils.c
+++ b/fsw/src/lc_utils.c
@@ -95,8 +95,7 @@ bool LC_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     }
 
     return (result);
-
-} /* End of LC_VerifyMsgLength */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -165,8 +164,7 @@ int32 LC_ManageTables(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* LC_ManageTables() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -220,8 +218,7 @@ int32 LC_UpdateTaskCDS(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* LC_UpdateTaskCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -60,8 +60,7 @@ uint32 LC_GetHashTableIndex(CFE_SB_MsgId_t MessageID)
     ** than 8 elements in its linked list.
     */
     return ((uint32)(CFE_SB_MsgIdToValue(MessageID) & LC_HASH_TABLE_MASK));
-
-} /* End of LC_GetHashTableIndex() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -133,8 +132,7 @@ void LC_CreateHashTable(void)
     }
 
     return;
-
-} /* End of LC_CreateHashTable() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -237,8 +235,7 @@ LC_WatchPtList_t *LC_AddWatchpoint(CFE_SB_MsgId_t MessageID)
 
     /* Return pointer to last link in watchpoint linked list */
     return (WatchPtLink);
-
-} /* End of LC_AddWatchpoint() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -325,8 +322,7 @@ void LC_CheckMsgForWPs(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
     }
 
     return;
-
-} /* end LC_CheckMsgForWPs */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -432,8 +428,7 @@ void LC_ProcessWP(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr, CFE_TIME_Sys
     } /* end SizedDataValid if */
 
     return;
-
-} /* end LC_ProcessWP */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -541,8 +536,7 @@ uint8 LC_OperatorCompare(uint16 WatchIndex, uint32 ProcessedWPData)
     }
 
     return (EvalResult);
-
-} /* end LC_OperatorCompare */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -595,8 +589,7 @@ uint8 LC_SignedCompare(uint16 WatchIndex, int32 WPValue, int32 CompareValue)
     }
 
     return (EvalResult);
-
-} /* end LC_SignedCompare */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -649,8 +642,7 @@ uint8 LC_UnsignedCompare(uint16 WatchIndex, uint32 WPValue, uint32 CompareValue)
     }
 
     return (EvalResult);
-
-} /* end LC_UnsignedCompare */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -736,8 +728,7 @@ uint8 LC_FloatCompare(uint16 WatchIndex, LC_MultiType_t *WPMultiType, LC_MultiTy
     }
 
     return (EvalResult);
-
-} /* end LC_FloatCompare */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -821,8 +812,7 @@ bool LC_WPOffsetValid(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr)
     }
 
     return (OffsetValid);
-
-} /* end LC_WPOffsetValid */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -934,8 +924,7 @@ bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedD
     ** Return success flag
     */
     return (Success);
-
-} /* end LC_GetSizedWPData */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1069,8 +1058,7 @@ int32 LC_ValidateWDT(void *TableData)
                       (int)UnusedCount);
 
     return (TableResult);
-
-} /* end LC_ValidateWDT */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1104,8 +1092,7 @@ bool LC_Uint32IsNAN(uint32 Data)
     }
 
     return (Result);
-
-} /* end LC_Uint32IsNAN */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1140,9 +1127,4 @@ bool LC_Uint32IsInfinite(uint32 Data)
     }
 
     return (Result);
-
-} /* end LC_Uint32IsInfinite */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/tables/lc_def_adt.c
+++ b/fsw/tables/lc_def_adt.c
@@ -2639,7 +2639,3 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
      .EventText         = {" "},
      .RPNEquation       = {              /* (WP_0) */
                      0, LC_RPN_EQUAL}}}; /* end LC_DefaultADT */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/lc_def_wdt.c
+++ b/fsw/tables/lc_def_wdt.c
@@ -2209,7 +2209,3 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
     }}; /* end LC_DefaultWDT */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/lc_action_tests.c
+++ b/unit-test/lc_action_tests.c
@@ -59,8 +59,7 @@ void LC_SampleAPs_Test_SingleActionPointNominal(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_SampleAPs_Test_SingleActionPointNominal */
+}
 
 void LC_SampleAPs_Test_SingleActionPointError(void)
 {
@@ -85,8 +84,7 @@ void LC_SampleAPs_Test_SingleActionPointError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleAPs_Test_SingleActionPointError */
+}
 
 void LC_SampleAPs_Test_MultiActionPointNominal(void)
 {
@@ -98,8 +96,7 @@ void LC_SampleAPs_Test_MultiActionPointNominal(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_SampleAPs_Test_MultiActionPointNominal */
+}
 
 void LC_SampleAPs_Test_SingleActionPointPermOff(void)
 {
@@ -124,8 +121,7 @@ void LC_SampleAPs_Test_SingleActionPointPermOff(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleAPs_Test_SingleActionPointError */
+}
 
 void LC_SampleSingleAP_Test_StateChangePassToFail(void)
 {
@@ -170,8 +166,7 @@ void LC_SampleSingleAP_Test_StateChangePassToFail(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_SampleSingleAP_Test_StateChangePassToFail */
+}
 
 void LC_SampleSingleAP_Test_StateChangePassToFailMaxChange(void)
 {
@@ -212,7 +207,7 @@ void LC_SampleSingleAP_Test_StateChangePassToFailMaxChange(void)
     /* Generates 1 event message we don't care about in this test */
 
     UtAssert_True(LC_AppData.RTSExecCount == 0, "LC_AppData.RTSExecCount == 0");
-} /* end LC_SampleSingleAP_Test_StateChangePassToFailMaxChange */
+}
 
 void LC_SampleSingleAP_Test_ActiveRequestRTS(void)
 {
@@ -252,8 +247,7 @@ void LC_SampleSingleAP_Test_ActiveRequestRTS(void)
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_OperData.ADTPtr[APNumber].EventID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, LC_OperData.ADTPtr[APNumber].EventType);
-
-} /* end LC_SampleSingleAP_Test_ActiveRequestRTS */
+}
 
 void LC_SampleSingleAP_Test_APFailWhileLCStatePassive(void)
 {
@@ -297,8 +291,7 @@ void LC_SampleSingleAP_Test_APFailWhileLCStatePassive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleSingleAP_Test_APFailWhileLCStatePassive */
+}
 
 void LC_SampleSingleAP_Test_APFailWhilePassive(void)
 {
@@ -348,8 +341,7 @@ void LC_SampleSingleAP_Test_APFailWhilePassive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleSingleAP_Test_APFailWhilePassive */
+}
 
 void LC_SampleSingleAP_Test_APFailWhilePassiveNoEvent(void)
 {
@@ -388,8 +380,7 @@ void LC_SampleSingleAP_Test_APFailWhilePassiveNoEvent(void)
                   "LC_OperData.ARTPtr[APNumber].CumulativeEventMsgsSent == 0");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_SampleSingleAP_Test_APFailWhilePassiveNoEvent */
+}
 
 void LC_SampleSingleAP_Test_StateChangeFailToPass(void)
 {
@@ -431,8 +422,7 @@ void LC_SampleSingleAP_Test_StateChangeFailToPass(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleSingleAP_Test_StateChangeFailToPass */
+}
 
 void LC_SampleSingleAP_Test_StateChangeFailToPassNoEvent(void)
 {
@@ -466,7 +456,7 @@ void LC_SampleSingleAP_Test_StateChangeFailToPassNoEvent(void)
                   "LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount == 0");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-} /* end LC_SampleSingleAP_Test_StateChangeFailToPass */
+}
 
 void LC_SampleSingleAP_Test_ActionStale(void)
 {
@@ -492,8 +482,7 @@ void LC_SampleSingleAP_Test_ActionStale(void)
                   "LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount == 0");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_SampleSingleAP_Test_ActionStale */
+}
 
 void LC_SampleSingleAP_Test_ActionError(void)
 {
@@ -527,8 +516,7 @@ void LC_SampleSingleAP_Test_ActionError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleSingleAP_Test_ActionError */
+}
 
 void LC_SampleSingleAP_Test_ConsecutivePass(void)
 {
@@ -558,8 +546,7 @@ void LC_SampleSingleAP_Test_ConsecutivePass(void)
 
     UtAssert_True(LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount == 0,
                   "LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount == 0");
-
-} /* end LC_SampleSingleAP_Test_StateChangeFailToPass */
+}
 
 void LC_EvaluateRPN_Test_AndWatchFalseOp1(void)
 {
@@ -581,8 +568,7 @@ void LC_EvaluateRPN_Test_AndWatchFalseOp1(void)
     UtAssert_True(Result == LC_ACTION_PASS, "Result == LC_ACTION_PASS");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndWatchFalseOp1 */
+}
 
 void LC_EvaluateRPN_Test_AndWatchFalseOp2(void)
 {
@@ -604,8 +590,7 @@ void LC_EvaluateRPN_Test_AndWatchFalseOp2(void)
     UtAssert_True(Result == LC_ACTION_PASS, "Result == LC_ACTION_PASS");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndWatchFalseOp2 */
+}
 
 void LC_EvaluateRPN_Test_OrWatchTrueOp1(void)
 {
@@ -627,8 +612,7 @@ void LC_EvaluateRPN_Test_OrWatchTrueOp1(void)
     UtAssert_True(Result == LC_ACTION_FAIL, "Result == LC_ACTION_FAIL");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrWatchTrueOp1 */
+}
 
 void LC_EvaluateRPN_Test_OrWatchTrueOp2(void)
 {
@@ -650,8 +634,7 @@ void LC_EvaluateRPN_Test_OrWatchTrueOp2(void)
     UtAssert_True(Result == LC_ACTION_FAIL, "Result == LC_ACTION_FAIL");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrWatchTrueOp2 */
+}
 
 void LC_EvaluateRPN_Test_AndWatchErrorOp1(void)
 {
@@ -673,8 +656,7 @@ void LC_EvaluateRPN_Test_AndWatchErrorOp1(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndWatchErrorOp1 */
+}
 
 void LC_EvaluateRPN_Test_AndWatchErrorOp2(void)
 {
@@ -696,8 +678,7 @@ void LC_EvaluateRPN_Test_AndWatchErrorOp2(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndWatchErrorOp2 */
+}
 
 void LC_EvaluateRPN_Test_OrWatchErrorOp1(void)
 {
@@ -719,8 +700,7 @@ void LC_EvaluateRPN_Test_OrWatchErrorOp1(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrWatchErrorOp1 */
+}
 
 void LC_EvaluateRPN_Test_OrWatchErrorOp2(void)
 {
@@ -742,8 +722,7 @@ void LC_EvaluateRPN_Test_OrWatchErrorOp2(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrWatchErrorOp2 */
+}
 
 void LC_EvaluateRPN_Test_XorWatchErrorOp1(void)
 {
@@ -765,8 +744,7 @@ void LC_EvaluateRPN_Test_XorWatchErrorOp1(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_XorWatchErrorOp1 */
+}
 
 void LC_EvaluateRPN_Test_XorWatchErrorOp2(void)
 {
@@ -788,8 +766,7 @@ void LC_EvaluateRPN_Test_XorWatchErrorOp2(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_XorWatchErrorOp2 */
+}
 
 void LC_EvaluateRPN_Test_NotWatchError(void)
 {
@@ -809,8 +786,7 @@ void LC_EvaluateRPN_Test_NotWatchError(void)
     UtAssert_True(Result == LC_ACTION_ERROR, "Result == LC_ACTION_ERROR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_NotWatchError */
+}
 
 void LC_EvaluateRPN_Test_AndStaleOp1(void)
 {
@@ -832,8 +808,7 @@ void LC_EvaluateRPN_Test_AndStaleOp1(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndStaleOp1 */
+}
 
 void LC_EvaluateRPN_Test_AndStaleOp2(void)
 {
@@ -855,8 +830,7 @@ void LC_EvaluateRPN_Test_AndStaleOp2(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndStaleOp2 */
+}
 
 void LC_EvaluateRPN_Test_OrStaleOp1(void)
 {
@@ -878,8 +852,7 @@ void LC_EvaluateRPN_Test_OrStaleOp1(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrStaleOp1 */
+}
 
 void LC_EvaluateRPN_Test_OrStaleOp2(void)
 {
@@ -901,8 +874,7 @@ void LC_EvaluateRPN_Test_OrStaleOp2(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrStaleOp2 */
+}
 
 void LC_EvaluateRPN_Test_XorStaleOp1(void)
 {
@@ -924,8 +896,7 @@ void LC_EvaluateRPN_Test_XorStaleOp1(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_XorStaleOp1 */
+}
 
 void LC_EvaluateRPN_Test_XorStaleOp2(void)
 {
@@ -947,8 +918,7 @@ void LC_EvaluateRPN_Test_XorStaleOp2(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_XorStaleOp2 */
+}
 
 void LC_EvaluateRPN_Test_NotStale(void)
 {
@@ -968,8 +938,7 @@ void LC_EvaluateRPN_Test_NotStale(void)
     UtAssert_True(Result == LC_ACTION_STALE, "Result == LC_ACTION_STALE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_NotStale */
+}
 
 void LC_EvaluateRPN_Test_AndNominal(void)
 {
@@ -991,8 +960,7 @@ void LC_EvaluateRPN_Test_AndNominal(void)
     UtAssert_True(Result == LC_ACTION_FAIL, "Result == LC_ACTION_FAIL");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_AndNominal */
+}
 
 void LC_EvaluateRPN_Test_OrNominal(void)
 {
@@ -1014,8 +982,7 @@ void LC_EvaluateRPN_Test_OrNominal(void)
     UtAssert_True(Result == LC_ACTION_PASS, "Result == LC_ACTION_PASS");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_OrNominal */
+}
 
 void LC_EvaluateRPN_Test_XorNominal(void)
 {
@@ -1037,8 +1004,7 @@ void LC_EvaluateRPN_Test_XorNominal(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_XorNominal */
+}
 
 void LC_EvaluateRPN_Test_NotNominal(void)
 {
@@ -1058,8 +1024,7 @@ void LC_EvaluateRPN_Test_NotNominal(void)
     UtAssert_True(Result == false, "Result == false");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_NotNominal */
+}
 
 void LC_EvaluateRPN_Test_Equal(void)
 {
@@ -1126,8 +1091,7 @@ void LC_EvaluateRPN_Test_WatchpointNumberNominal(void)
     UtAssert_True(Result == 77, "Result == 77");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_EvaluateRPN_Test_WatchpointNumberNominal */
+}
 
 void LC_EvaluateRPN_Test_DefaultIllegalRPN(void)
 {
@@ -1154,8 +1118,7 @@ void LC_EvaluateRPN_Test_DefaultIllegalRPN(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_EvaluateRPN_Test_DefaultIllegalRPN */
+}
 
 void LC_EvaluateRPN_Test_EndOfBufferWhenNotDone(void)
 {
@@ -1190,8 +1153,7 @@ void LC_EvaluateRPN_Test_EndOfBufferWhenNotDone(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_EvaluateRPN_Test_EndOfBufferWhenNotDone */
+}
 
 void LC_EvaluateRPN_Test_PushPopFail(void)
 {
@@ -1306,8 +1268,7 @@ void LC_ValidateADT_Test_ActionNotUsed(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ValidateADT_Test_ActionNotUsed */
+}
 
 void LC_ValidateADT_Test_InvalidDefaultState(void)
 {
@@ -1349,8 +1310,7 @@ void LC_ValidateADT_Test_InvalidDefaultState(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateADT_Test_InvalidDefaultState */
+}
 
 void LC_ValidateADT_Test_BadRtsID(void)
 {
@@ -1392,8 +1352,7 @@ void LC_ValidateADT_Test_BadRtsID(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateADT_Test_BadRtsID */
+}
 
 void LC_ValidateADT_Test_BadFailCount(void)
 {
@@ -1434,8 +1393,7 @@ void LC_ValidateADT_Test_BadFailCount(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateADT_Test_BadFailCount */
+}
 
 void LC_ValidateADT_Test_InvalidEventType(void)
 {
@@ -1477,8 +1435,7 @@ void LC_ValidateADT_Test_InvalidEventType(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateADT_Test_InvalidEventType */
+}
 
 void LC_ValidateADT_Test_ValidateRpnAdtValError(void)
 {
@@ -1521,8 +1478,7 @@ void LC_ValidateADT_Test_ValidateRpnAdtValError(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateADT_Test_ValidateRpnAdtValError */
+}
 
 void LC_ValidateADT_Test_ValidateRpnAdtValNoError(void)
 {
@@ -1559,8 +1515,7 @@ void LC_ValidateADT_Test_ValidateRpnAdtValNoError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ValidateADT_Test_ValidateRpnAdtValNoError */
+}
 
 void LC_ValidateADT_Test_Nominal(void)
 {
@@ -1627,8 +1582,7 @@ void LC_ValidateRPN_Test_RpnAnd(void)
     UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_RpnAnd */
+}
 
 void LC_ValidateRPN_Test_RpnOr(void)
 {
@@ -1648,8 +1602,7 @@ void LC_ValidateRPN_Test_RpnOr(void)
     UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_RpnOr */
+}
 
 void LC_ValidateRPN_Test_RpnXor(void)
 {
@@ -1669,8 +1622,7 @@ void LC_ValidateRPN_Test_RpnXor(void)
     UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_RpnXor */
+}
 
 void LC_ValidateRPN_Test_RpnNot(void)
 {
@@ -1689,8 +1641,7 @@ void LC_ValidateRPN_Test_RpnNot(void)
     UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_RpnNot */
+}
 
 void LC_ValidateRPN_Test_StackDepthZero(void)
 {
@@ -1710,8 +1661,7 @@ void LC_ValidateRPN_Test_StackDepthZero(void)
     UtAssert_True(StackDepthValue == 0, "StackDepthValue == 0");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_StackDepthZero */
+}
 
 void LC_ValidateRPN_Test_StackDepthZero2(void)
 {
@@ -1731,8 +1681,7 @@ void LC_ValidateRPN_Test_StackDepthZero2(void)
     UtAssert_True(StackDepthValue == 0, "StackDepthValue == 0");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_StackDepthZero2 */
+}
 
 void LC_ValidateRPN_Test_MaxRPNSize(void)
 {
@@ -1755,8 +1704,7 @@ void LC_ValidateRPN_Test_MaxRPNSize(void)
     UtAssert_True(StackDepthValue == LC_MAX_RPN_EQU_SIZE, "StackDepthValue == LC_MAX_RPN_EQU_SIZE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_StackDepthZero2 */
+}
 
 void LC_ValidateRPN_Test_InvalidBufferItem(void)
 {
@@ -1776,8 +1724,7 @@ void LC_ValidateRPN_Test_InvalidBufferItem(void)
     UtAssert_True(StackDepthValue == 0, "StackDepthValue == 0");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ValidateRPN_Test_InvalidBufferItem */
+}
 
 void UtTest_Setup(void)
 {
@@ -1883,6 +1830,3 @@ void UtTest_Setup(void)
     UtTest_Add(LC_ValidateRPN_Test_InvalidBufferItem, LC_Test_Setup, LC_Test_TearDown,
                "LC_ValidateRPN_Test_InvalidBufferItem");
 }
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/lc_app_tests.c
+++ b/unit-test/lc_app_tests.c
@@ -280,7 +280,7 @@ void LC_AppInit_Test_Nominal(void)
     /* Verify results */
     sprintf(Message, "LC Initialized. Version %d.%d.%d.%d", LC_MAJOR_VERSION, LC_MINOR_VERSION, LC_REVISION,
             LC_MISSION_REV);
-    //    UtAssert_True (Ut_CFE_EVS_EventSent(LC_INIT_INF_EID, CFE_EVS_INFORMATION, Message), Message);
+    /*    UtAssert_True (Ut_CFE_EVS_EventSent(LC_INIT_INF_EID, CFE_EVS_INFORMATION, Message), Message); */
 
     UtAssert_INT32_EQ(Result, CFE_SUCCESS);
 
@@ -324,8 +324,7 @@ void LC_AppInit_Test_Nominal(void)
     /* Generates 2 event message we don't care about in this test */
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 #endif
-
-} /* end LC_AppInit_Test_Nominal */
+}
 
 void LC_AppInit_Test_EVSInitError(void)
 {
@@ -345,8 +344,7 @@ void LC_AppInit_Test_EVSInitError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_AppInit_Test_EVSInitError */
+}
 
 void LC_AppInit_Test_SBInitError(void)
 {
@@ -367,8 +365,7 @@ void LC_AppInit_Test_SBInitError(void)
     /* Generates one event message we don't care about in this test */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_AppInit_Test_SBInitError */
+}
 
 void LC_AppInit_Test_TableInitError(void)
 {
@@ -386,8 +383,7 @@ void LC_AppInit_Test_TableInitError(void)
     /* Generates one event message we don't care about in this test */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_AppInit_Test_TableInitError */
+}
 
 void LC_EvsInit_Test_Nominal(void)
 {
@@ -401,8 +397,7 @@ void LC_EvsInit_Test_Nominal(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_EvsInit_Test_Nominal */
+}
 
 void LC_EvsInit_Test_EVSRegisterError(void)
 {
@@ -423,8 +418,7 @@ void LC_EvsInit_Test_EVSRegisterError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_EvsInit_Test_EVSRegisterError */
+}
 
 void LC_SbInit_Test_Nominal(void)
 {
@@ -438,8 +432,7 @@ void LC_SbInit_Test_Nominal(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_SbInit_Test_Nominal */
+}
 
 void LC_SbInit_Test_CreatePipeError(void)
 {
@@ -460,8 +453,7 @@ void LC_SbInit_Test_CreatePipeError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_SbInit_Test_CreatePipeError */
+}
 
 void LC_SbInit_Test_SubscribeHKReqError(void)
 {
@@ -482,8 +474,7 @@ void LC_SbInit_Test_SubscribeHKReqError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_SbInit_Test_SubscribeHKReqError */
+}
 
 void LC_SbInit_Test_SubscribeGndCmdError(void)
 {
@@ -504,8 +495,7 @@ void LC_SbInit_Test_SubscribeGndCmdError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_SbInit_Test_SubscribeGndCmdError */
+}
 
 void LC_SbInit_Test_SubscribeSampleCmdError(void)
 {
@@ -526,8 +516,7 @@ void LC_SbInit_Test_SubscribeSampleCmdError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_SbInit_Test_SubscribeSampleCmdError */
+}
 
 void LC_TableInit_Test_CreateResultsTablesError(void)
 {
@@ -815,8 +804,7 @@ void LC_CreateResultTables_Test_Nominal(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_CreateResultTables_Test_Nominal */
+}
 
 void LC_CreateResultTables_Test_WRTRegisterError(void)
 {
@@ -840,8 +828,7 @@ void LC_CreateResultTables_Test_WRTRegisterError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_CreateResultTables_Test_WRTRegisterError */
+}
 
 void LC_CreateResultTables_Test_WRTGetAddressError(void)
 {
@@ -865,8 +852,7 @@ void LC_CreateResultTables_Test_WRTGetAddressError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_CreateResultTables_Test_WRTGetAddressError */
+}
 
 void LC_CreateResultTables_Test_ARTRegisterError(void)
 {
@@ -890,8 +876,7 @@ void LC_CreateResultTables_Test_ARTRegisterError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_CreateResultTables_Test_ARTRegisterError */
+}
 
 void LC_CreateResultTables_Test_ARTGetAddressError(void)
 {
@@ -915,8 +900,7 @@ void LC_CreateResultTables_Test_ARTGetAddressError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_CreateResultTables_Test_ARTGetAddressError */
+}
 
 void LC_CreateDefinitionTables_Test_NominalCDSActive(void)
 {
@@ -938,8 +922,7 @@ void LC_CreateDefinitionTables_Test_NominalCDSActive(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_CreateDefinitionTables_Test_NominalCDSActive */
+}
 
 void LC_CreateDefinitionTables_Test_NominalCDSInactive(void)
 {
@@ -961,8 +944,7 @@ void LC_CreateDefinitionTables_Test_NominalCDSInactive(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_CreateDefinitionTables_Test_NominalCDSInactive */
+}
 
 void LC_CreateDefinitionTables_Test_WDTReRegisterThenInfoRecovered(void)
 {
@@ -1000,8 +982,7 @@ void LC_CreateDefinitionTables_Test_WDTReRegisterThenInfoRecovered(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_CreateDefinitionTables_Test_WDTReRegisterThenInfoRecovered */
+}
 
 void LC_CreateDefinitionTables_Test_ADTReRegisterThenInfoRecovered(void)
 {
@@ -1039,8 +1020,7 @@ void LC_CreateDefinitionTables_Test_ADTReRegisterThenInfoRecovered(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_CreateDefinitionTables_Test_ADTReRegisterThenInfoRecovered */
+}
 
 void LC_CreateDefinitionTables_Test_WDTCriticalADTNoncritical(void)
 {
@@ -1066,8 +1046,7 @@ void LC_CreateDefinitionTables_Test_WDTCriticalADTNoncritical(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_CreateDefinitionTables_Test_WDTCriticalADTNoncritical */
+}
 
 void LC_CreateDefinitionTables_Test_WDTReRegisterError(void)
 {
@@ -1089,8 +1068,7 @@ void LC_CreateDefinitionTables_Test_WDTReRegisterError(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_WDT_REREGISTER_ERR_EID);
-
-} /* end LC_CreateDefinitionTables_Test_WDTReRegisterError */
+}
 
 void LC_CreateDefinitionTables_Test_WDTRegisterError(void)
 {
@@ -1106,8 +1084,7 @@ void LC_CreateDefinitionTables_Test_WDTRegisterError(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_WDT_REGISTER_ERR_EID);
-
-} /* end LC_CreateDefinitionTables_Test_WDTRegisterError */
+}
 
 void LC_CreateDefinitionTables_Test_ADTRegisterError(void)
 {
@@ -1122,8 +1099,7 @@ void LC_CreateDefinitionTables_Test_ADTRegisterError(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_ADT_REGISTER_ERR_EID);
-
-} /* end LC_CreateDefinitionTables_Test_ADTRegisterError */
+}
 
 void LC_LoadDefaultTables_Test_NominalActiveCDS(void)
 {
@@ -1153,8 +1129,7 @@ void LC_LoadDefaultTables_Test_NominalActiveCDS(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_LoadDefaultTables_Test_NominalActiveCDS */
+}
 
 void LC_LoadDefaultTables_Test_ActiveCDSNotSuccess(void)
 {
@@ -1188,8 +1163,7 @@ void LC_LoadDefaultTables_Test_ActiveCDSNotSuccess(void)
     /* Generates one event message we don't care about in this test */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_LoadDefaultTables_Test_ActiveCDSNotSuccess */
+}
 
 void LC_LoadDefaultTables_Test_NominalInactiveCDS(void)
 {
@@ -1218,8 +1192,7 @@ void LC_LoadDefaultTables_Test_NominalInactiveCDS(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_LoadDefaultTables_Test_NominalInactiveCDS */
+}
 
 void LC_LoadDefaultTables_Test_LoadWDTError(void)
 {
@@ -1242,8 +1215,7 @@ void LC_LoadDefaultTables_Test_LoadWDTError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_LoadDefaultTables_Test_LoadWDTError */
+}
 
 void LC_LoadDefaultTables_Test_GetWDTAddressError(void)
 {
@@ -1269,8 +1241,7 @@ void LC_LoadDefaultTables_Test_GetWDTAddressError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_LoadDefaultTables_Test_GetWDTAddressError */
+}
 
 void LC_LoadDefaultTables_Test_LoadADTError(void)
 {
@@ -1296,8 +1267,7 @@ void LC_LoadDefaultTables_Test_LoadADTError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end LC_LoadDefaultTables_Test_LoadADTError */
+}
 
 void LC_LoadDefaultTables_Test_GetADTAddressError(void)
 {
@@ -1318,8 +1288,7 @@ void LC_LoadDefaultTables_Test_GetADTAddressError(void)
         "Error getting ADT address, RC=0xCC000001");
 */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end LC_LoadDefaultTables_Test_GetADTAddressError */
+}
 
 void LC_LoadDefaultTables_Test_InfoUpdated(void)
 {
@@ -1349,8 +1318,7 @@ void LC_LoadDefaultTables_Test_InfoUpdated(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_LoadDefaultTables_Test_NominalActiveCDS */
+}
 
 void LC_CreateTaskCDS_Test_Nominal(void)
 {
@@ -1534,7 +1502,6 @@ void LC_CreateTaskCDS_Test_RestoreFail(void)
 
 void UtTest_Setup(void)
 {
-
     UtTest_Add(LC_AppMain_Test_Nominal, LC_Test_Setup, LC_Test_TearDown, "LC_AppMain_Test_Nominal");
 
     UtTest_Add(LC_AppMain_Test_NominalCDSSave, LC_Test_Setup, LC_Test_TearDown, "LC_AppMain_Test_NominalCDSSave");
@@ -1567,8 +1534,8 @@ void UtTest_Setup(void)
 
     UtTest_Add(LC_TableInit_Test_CreateTaskCDSError, LC_Test_Setup, LC_Test_TearDown,
                "LC_TableInit_Test_CreateTaskCDSError");
-    // UtTest_Add(LC_TableInit_Test_CDSRestored, LC_Test_Setup, LC_Test_TearDown, "LC_TableInit_Test_CDSRestored");
-    // UtTest_Add(LC_TableInit_Test_CDSUpdated, LC_Test_Setup, LC_Test_TearDown, "LC_TableInit_Test_CDSUpdated");
+    /* UtTest_Add(LC_TableInit_Test_CDSRestored, LC_Test_Setup, LC_Test_TearDown, "LC_TableInit_Test_CDSRestored"); */
+    /* UtTest_Add(LC_TableInit_Test_CDSUpdated, LC_Test_Setup, LC_Test_TearDown, "LC_TableInit_Test_CDSUpdated"); */
     UtTest_Add(LC_TableInit_Test_CreateResultsTablesError, LC_Test_Setup, LC_Test_TearDown,
                "LC_TableInit_Test_CreateResultsTablesError");
     UtTest_Add(LC_TableInit_Test_CreateDefinitionTablesError, LC_Test_Setup, LC_Test_TearDown,
@@ -1643,9 +1610,4 @@ void UtTest_Setup(void)
     UtTest_Add(LC_CreateTaskCDS_Test_RestoreSuccessCDSNotSaved, LC_Test_Setup, LC_Test_TearDown,
                "LC_CreateTaskCDS_Test_RestoreSuccessCDSNotSaved");
     UtTest_Add(LC_CreateTaskCDS_Test_RestoreFail, LC_Test_Setup, LC_Test_TearDown, "LC_CreateTaskCDS_Test_RestoreFail");
-
-} /* end LC_App_Test_AddTestCases */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/lc_cmds_tests.c
+++ b/unit-test/lc_cmds_tests.c
@@ -61,8 +61,7 @@ void LC_AppPipe_Test_SampleAPRequest(void)
 
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-} /* end LC_AppPipe_Test_SampleAPRequest */
+}
 
 void LC_AppPipe_Test_HousekeepingRequest(void)
 {
@@ -89,8 +88,7 @@ void LC_AppPipe_Test_HousekeepingRequest(void)
     uint8 call_count_LC_PerformMaintenance = UT_GetStubCount(UT_KEY(LC_PerformMaintenance));
     UtAssert_INT32_EQ(call_count_LC_PerformMaintenance, 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_AppPipe_Test_HousekeepingRequest */
+}
 
 void LC_AppPipe_Test_Noop(void)
 {
@@ -125,8 +123,7 @@ void LC_AppPipe_Test_Noop(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_AppPipe_Test_Noop */
+}
 
 void LC_AppPipe_Test_Reset(void)
 {
@@ -161,8 +158,7 @@ void LC_AppPipe_Test_Reset(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_AppPipe_Test_Reset */
+}
 
 void LC_AppPipe_Test_SetLCState(void)
 {
@@ -187,8 +183,7 @@ void LC_AppPipe_Test_SetLCState(void)
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_AppPipe_Test_SetLCState */
+}
 
 void LC_AppPipe_Test_SetAPState(void)
 {
@@ -213,8 +208,7 @@ void LC_AppPipe_Test_SetAPState(void)
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_AppPipe_Test_SetAPState */
+}
 
 void LC_AppPipe_Test_SetAPPermoff(void)
 {
@@ -239,8 +233,7 @@ void LC_AppPipe_Test_SetAPPermoff(void)
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_AppPipe_Test_SetAPPermoff */
+}
 
 void LC_AppPipe_Test_ResetAPStats(void)
 {
@@ -264,8 +257,7 @@ void LC_AppPipe_Test_ResetAPStats(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_AppPipe_Test_ResetAPStats */
+}
 
 void LC_AppPipe_Test_ResetWPStats(void)
 {
@@ -289,8 +281,7 @@ void LC_AppPipe_Test_ResetWPStats(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_AppPipe_Test_ResetWPStats */
+}
 
 void LC_AppPipe_Test_InvalidCommandCode(void)
 {
@@ -323,8 +314,7 @@ void LC_AppPipe_Test_InvalidCommandCode(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_AppPipe_Test_InvalidCommandCode */
+}
 
 void LC_AppPipe_Test_MonitorPacket(void)
 {
@@ -345,12 +335,10 @@ void LC_AppPipe_Test_MonitorPacket(void)
 
     uint8 call_count_LC_CheckMsgForWPs = UT_GetStubCount(UT_KEY(LC_CheckMsgForWPs));
     UtAssert_INT32_EQ(call_count_LC_CheckMsgForWPs, 1);
-
-} /* end LC_AppPipe_Test_MonitorPacket */
+}
 
 void LC_SampleAPReq_Test_BadLength(void)
 {
-
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), false);
 
     LC_SampleAPReq(&UT_CmdBuf.Buf);
@@ -358,7 +346,6 @@ void LC_SampleAPReq_Test_BadLength(void)
 
 void LC_SampleAPReq_Test_StateDisabled(void)
 {
-
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
     LC_AppData.CurrentLCState = LC_STATE_DISABLED;
@@ -390,8 +377,7 @@ void LC_SampleAPReq_Test_AllowSampleAllWatchStale(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_SampleAPReq_Test_AllowSampleAllWatchStale */
+}
 
 void LC_SampleAPReq_Test_AllowSampleAllWatchNotStale(void)
 {
@@ -414,8 +400,7 @@ void LC_SampleAPReq_Test_AllowSampleAllWatchNotStale(void)
     /* Verify results */
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_SampleAPReq_Test_AllowSampleAllWatchStale */
+}
 
 void LC_SampleAPReq_Test_StartLessOrEqualToEndAndEndWithinArrayWatchStale(void)
 {
@@ -441,8 +426,7 @@ void LC_SampleAPReq_Test_StartLessOrEqualToEndAndEndWithinArrayWatchStale(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_SampleAPReq_Test_StartLessOrEqualToEndAndEndWithinArrayWatchStale */
+}
 
 void LC_SampleAPReq_Test_ArrayIndexOutOfRange(void)
 {
@@ -475,8 +459,7 @@ void LC_SampleAPReq_Test_ArrayIndexOutOfRange(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SampleAPReq_Test_ArrayIndexOutOfRange */
+}
 
 void LC_SampleAPReq_Test_BadSampleAllArgs(void)
 {
@@ -619,8 +602,7 @@ void LC_HousekeepingReq_Test_WatchStale(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_WatchStale */
+}
 
 void LC_HousekeepingReq_Test_WatchFalse(void)
 {
@@ -671,8 +653,7 @@ void LC_HousekeepingReq_Test_WatchFalse(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_WatchFalse */
+}
 
 void LC_HousekeepingReq_Test_WatchTrue(void)
 {
@@ -723,8 +704,7 @@ void LC_HousekeepingReq_Test_WatchTrue(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_WatchTrue */
+}
 
 void LC_HousekeepingReq_Test_WatchError(void)
 {
@@ -776,8 +756,7 @@ void LC_HousekeepingReq_Test_WatchError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_WatchError */
+}
 
 void LC_HousekeepingReq_Test_DefaultWatchResult(void)
 {
@@ -828,8 +807,7 @@ void LC_HousekeepingReq_Test_DefaultWatchResult(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_DefaultWatchResult */
+}
 
 void LC_HousekeepingReq_Test_ActionNotUsedStale(void)
 {
@@ -881,8 +859,7 @@ void LC_HousekeepingReq_Test_ActionNotUsedStale(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_ActionNotUsedStale */
+}
 
 void LC_HousekeepingReq_Test_APStateActiveActionPass(void)
 {
@@ -937,8 +914,7 @@ void LC_HousekeepingReq_Test_APStateActiveActionPass(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_APStateActiveActionPass */
+}
 
 void LC_HousekeepingReq_Test_APStatePassiveActionFail(void)
 {
@@ -990,8 +966,7 @@ void LC_HousekeepingReq_Test_APStatePassiveActionFail(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_APStatePassiveActionFail */
+}
 
 void LC_HousekeepingReq_Test_APStateDisabledActionError(void)
 {
@@ -1043,8 +1018,7 @@ void LC_HousekeepingReq_Test_APStateDisabledActionError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_APStateDisabledActionError */
+}
 
 void LC_HousekeepingReq_Test_APStatePermOffActionError(void)
 {
@@ -1096,8 +1070,7 @@ void LC_HousekeepingReq_Test_APStatePermOffActionError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_APStatePermOffActionError */
+}
 
 void LC_HousekeepingReq_Test_DefaultCurrentStateAndActionResult(void)
 {
@@ -1149,8 +1122,7 @@ void LC_HousekeepingReq_Test_DefaultCurrentStateAndActionResult(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_DefaultCurrentStateAndActionResult */
+}
 
 void LC_HousekeepingReq_Test_ManageTablesError(void)
 {
@@ -1174,8 +1146,7 @@ void LC_HousekeepingReq_Test_ManageTablesError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_HousekeepingReq_Test_ManageTablesError */
+}
 
 void LC_NoopCmd_Test_BadLength(void)
 {
@@ -1218,8 +1189,7 @@ void LC_ResetCounters_Test(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_ResetCounters_Test */
+}
 
 void LC_SetLCStateCmd_Test_BadLength(void)
 {
@@ -1260,8 +1230,7 @@ void LC_SetLCStateCmd_Test_Active(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetLCStateCmd_Test_Active */
+}
 
 void LC_SetLCStateCmd_Test_Passive(void)
 {
@@ -1293,7 +1262,7 @@ void LC_SetLCStateCmd_Test_Passive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-} /* end LC_SetLCStateCmd_Test_Passive */
+}
 
 void LC_SetLCStateCmd_Test_Disabled(void)
 {
@@ -1325,8 +1294,7 @@ void LC_SetLCStateCmd_Test_Disabled(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetLCStateCmd_Test_Disabled */
+}
 
 void LC_SetLCStateCmd_Test_Default(void)
 {
@@ -1357,8 +1325,7 @@ void LC_SetLCStateCmd_Test_Default(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetLCStateCmd_Test_Default */
+}
 
 void LC_SetAPStateCmd_Test_BadLength(void)
 {
@@ -1400,8 +1367,7 @@ void LC_SetAPStateCmd_Test_Default(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_Default */
+}
 
 void LC_SetAPStateCmd_Test_SetAllActionPointsActive(void)
 {
@@ -1454,7 +1420,7 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-} /* end LC_SetAPStateCmd_Test_SetAllActionPointsActive */
+}
 
 void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOneNotUsed(void)
 {
@@ -1508,7 +1474,7 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOneNotUsed(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-} /* end LC_SetAPStateCmd_Test_SetAllActionPointsActiveOneNotUsed */
+}
 
 void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOnePermOff(void)
 {
@@ -1562,7 +1528,7 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOnePermOff(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-} /* end LC_SetAPStateCmd_Test_SetAllActionPointsActiveOnePermOff */
+}
 
 void LC_SetAPStateCmd_Test_SetAllActionPointsPassive(void)
 {
@@ -1615,8 +1581,7 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsPassive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_SetAllActionPointsPassive */
+}
 
 void LC_SetAPStateCmd_Test_SetAllActionPointsDisabled(void)
 {
@@ -1669,8 +1634,7 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsDisabled(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_SetAllActionPointsDisabled */
+}
 
 void LC_SetAPStateCmd_Test_UpdateSingleActionPointActive(void)
 {
@@ -1706,8 +1670,7 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointActive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_UpdateSingleActionPointActive */
+}
 
 void LC_SetAPStateCmd_Test_UpdateSingleActionPointNotUsed(void)
 {
@@ -1743,8 +1706,7 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointNotUsed(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_UpdateSingleActionPointActive */
+}
 
 void LC_SetAPStateCmd_Test_UpdateSingleActionPointPassive(void)
 {
@@ -1780,8 +1742,7 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointPassive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_UpdateSingleActionPointPassive */
+}
 
 void LC_SetAPStateCmd_Test_UpdateSingleActionPointDisabled(void)
 {
@@ -1817,8 +1778,7 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointDisabled(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_UpdateSingleActionPointDisabled */
+}
 
 void LC_SetAPStateCmd_Test_InvalidCurrentAPStateActive(void)
 {
@@ -1853,8 +1813,7 @@ void LC_SetAPStateCmd_Test_InvalidCurrentAPStateActive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_InvalidCurrentAPStateActive */
+}
 
 void LC_SetAPStateCmd_Test_InvalidCurrentAPStatePassive(void)
 {
@@ -1889,8 +1848,7 @@ void LC_SetAPStateCmd_Test_InvalidCurrentAPStatePassive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_InvalidCurrentAPStatePassive */
+}
 
 void LC_SetAPStateCmd_Test_InvalidCurrentAPStateDisabled(void)
 {
@@ -1926,8 +1884,7 @@ void LC_SetAPStateCmd_Test_InvalidCurrentAPStateDisabled(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_InvalidCurrentAPStateDisabled */
+}
 
 void LC_SetAPStateCmd_Test_InvalidAPNumberActive(void)
 {
@@ -1961,8 +1918,7 @@ void LC_SetAPStateCmd_Test_InvalidAPNumberActive(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_InvalidAPNumberActive */
+}
 
 void LC_SetAPStateCmd_Test_InvalidAPNumberPassive(void)
 {
@@ -1995,8 +1951,7 @@ void LC_SetAPStateCmd_Test_InvalidAPNumberPassive(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_InvalidAPNumberPassive */
+}
 
 void LC_SetAPStateCmd_Test_InvalidAPNumberDisabled(void)
 {
@@ -2028,8 +1983,7 @@ void LC_SetAPStateCmd_Test_InvalidAPNumberDisabled(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPStateCmd_Test_InvalidAPNumberDisabled */
+}
 
 void LC_SetAPPermOffCmd_Test_BadLength(void)
 {
@@ -2068,8 +2022,7 @@ void LC_SetAPPermOffCmd_Test_InvalidAPNumberMaxActionpoints(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPPermOffCmd_Test_InvalidAPNumberMaxActionpoints */
+}
 
 void LC_SetAPPermOffCmd_Test_InvalidAPNumberAllActionpoints(void)
 {
@@ -2099,8 +2052,7 @@ void LC_SetAPPermOffCmd_Test_InvalidAPNumberAllActionpoints(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPPermOffCmd_Test_InvalidAPNumberAllActionpoints */
+}
 
 void LC_SetAPPermOffCmd_Test_APNotDisabled(void)
 {
@@ -2133,8 +2085,7 @@ void LC_SetAPPermOffCmd_Test_APNotDisabled(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPPermOffCmd_Test_APNotDisabled */
+}
 
 void LC_SetAPPermOffCmd_Test_Nominal(void)
 {
@@ -2168,8 +2119,7 @@ void LC_SetAPPermOffCmd_Test_Nominal(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SetAPPermOffCmd_Test_Nominal */
+}
 
 void LC_ResetAPStatsCmd_Test_BadLength(void)
 {
@@ -2208,8 +2158,7 @@ void LC_ResetAPStatsCmd_Test_AllActionPoints(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ResetAPStatsCmd_Test_AllActionPoints */
+}
 
 void LC_ResetAPStatsCmd_Test_SingleActionPoint(void)
 {
@@ -2239,8 +2188,7 @@ void LC_ResetAPStatsCmd_Test_SingleActionPoint(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ResetAPStatsCmd_Test_SingleActionPoint */
+}
 
 void LC_ResetAPStatsCmd_Test_InvalidAPNumber(void)
 {
@@ -2270,8 +2218,7 @@ void LC_ResetAPStatsCmd_Test_InvalidAPNumber(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ResetAPStatsCmd_Test_InvalidAPNumber */
+}
 
 void LC_ResetResultsAP_Test(void)
 {
@@ -2372,8 +2319,7 @@ void LC_ResetResultsAP_Test(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_ResetResultsAP_Test */
+}
 
 void LC_ResetWPStatsCmd_Test_BadLength(void)
 {
@@ -2412,8 +2358,7 @@ void LC_ResetWPStatsCmd_Test_AllWatchPoints(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ResetWPStatsCmd_Test_AllWatchPoints */
+}
 
 void LC_ResetWPStatsCmd_Test_SingleWatchPoint(void)
 {
@@ -2442,8 +2387,7 @@ void LC_ResetWPStatsCmd_Test_SingleWatchPoint(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ResetWPStatsCmd_Test_SingleWatchPoint */
+}
 
 void LC_ResetWPStatsCmd_Test_InvalidWPNumber(void)
 {
@@ -2473,8 +2417,7 @@ void LC_ResetWPStatsCmd_Test_InvalidWPNumber(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ResetWPStatsCmd_Test_InvalidWPNumber */
+}
 
 void LC_ResetResultsWP_Test(void)
 {
@@ -2602,8 +2545,7 @@ void LC_ResetResultsWP_Test(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_ResetResultsWP_Test */
+}
 
 void UtTest_Setup(void)
 {
@@ -2735,7 +2677,3 @@ void UtTest_Setup(void)
     UtTest_Add(LC_ResetWPStatsCmd_Test_BadLength, LC_Test_Setup, LC_Test_TearDown, "LC_ResetWPStatsCmd_Test_BadLength");
     UtTest_Add(LC_ResetResultsWP_Test, LC_Test_Setup, LC_Test_TearDown, "LC_ResetResultsWP_Test");
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/lc_custom_tests.c
+++ b/unit-test/lc_custom_tests.c
@@ -54,8 +54,7 @@ void LC_ExecuteRTS_Test(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-
-} /* end LC_ExecuteRTS_Test */
+}
 
 void LC_CustomFunction_Test_WatchIndex0(void)
 {
@@ -79,8 +78,7 @@ void LC_CustomFunction_Test_WatchIndex0(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_CustomFunction_Test_WatchIndex0 */
+}
 
 void LC_CustomFunction_Test_WatchIndex1(void)
 {
@@ -104,8 +102,7 @@ void LC_CustomFunction_Test_WatchIndex1(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_CustomFunction_Test_WatchIndex1 */
+}
 
 void UtTest_Setup(void)
 {
@@ -115,6 +112,3 @@ void UtTest_Setup(void)
     UtTest_Add(LC_CustomFunction_Test_WatchIndex1, LC_Test_Setup, LC_Test_TearDown,
                "LC_CustomFunction_Test_WatchIndex1");
 }
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/lc_utils_tests.c
+++ b/unit-test/lc_utils_tests.c
@@ -70,8 +70,7 @@ void LC_VerifyMsgLength_Test_HKRequestLengthError(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_VerifyMsgLength_Test_HKRequestLengthError */
+}
 
 void LC_VerifyMsgLength_Test_APSampleLengthError(void)
 {
@@ -106,8 +105,7 @@ void LC_VerifyMsgLength_Test_APSampleLengthError(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_VerifyMsgLength_Test_APSampleLengthError */
+}
 
 void LC_VerifyMsgLength_Test_GenericLengthError(void)
 {
@@ -144,8 +142,7 @@ void LC_VerifyMsgLength_Test_GenericLengthError(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_VerifyMsgLength_Test_GenericLengthError */
+}
 
 void LC_VerifyMsgLength_Test_Nominal(void)
 {
@@ -170,8 +167,7 @@ void LC_VerifyMsgLength_Test_Nominal(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_VerifyMsgLength_Test_Nominal */
+}
 
 void LC_ManageTables_Test_Nominal(void)
 {
@@ -216,8 +212,7 @@ void LC_ManageTables_Test_InfoUpdated(void)
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsWP, 1);
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 1);
-
-} /* end LC_ManageTables_Test_InfoUpdated */
+}
 
 void LC_ManageTables_Test_WDTGetAddressError(void)
 {
@@ -249,8 +244,7 @@ void LC_ManageTables_Test_WDTGetAddressError(void)
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsWP, 0);
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 0);
-
-} /* end LC_ManageTables_Test_WDTGetAddressError */
+}
 
 void LC_ManageTables_Test_ADTGetAddressError(void)
 {
@@ -280,8 +274,7 @@ void LC_ManageTables_Test_ADTGetAddressError(void)
     uint8 call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 0);
-
-} /* end LC_ManageTables_Test_ADTGetAddressError */
+}
 
 void LC_UpdateTaskCDS_Test_UpdateWatchpointError(void)
 {
@@ -308,8 +301,7 @@ void LC_UpdateTaskCDS_Test_UpdateWatchpointError(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_UpdateTaskCDS_Test_UpdateWatchpointError */
+}
 
 void LC_UpdateTaskCDS_Test_UpdateActionpointError(void)
 {
@@ -335,8 +327,7 @@ void LC_UpdateTaskCDS_Test_UpdateActionpointError(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_UpdateTaskCDS_Test_UpdateActionpointError */
+}
 
 void LC_UpdateTaskCDS_Test_UpdateAppDataError(void)
 {
@@ -364,8 +355,7 @@ void LC_UpdateTaskCDS_Test_UpdateAppDataError(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_UpdateTaskCDS_Test_UpdateAppDataError */
+}
 
 void LC_UpdateTaskCDS_Test_Nominal(void)
 {
@@ -380,8 +370,7 @@ void LC_UpdateTaskCDS_Test_Nominal(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-} /* end LC_UpdateTaskCDS_Test_Nominal */
+}
 
 void LC_PerformMaintenance_Test_NominalNoCDS(void)
 {

--- a/unit-test/lc_watch_tests.c
+++ b/unit-test/lc_watch_tests.c
@@ -168,8 +168,7 @@ void LC_AddWatchpoint_Test_NullPointersErrorSubscribingWatchpoint(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_AddWatchpoint_Test_NullPointersErrorSubscribingWatchpoint */
+}
 
 void LC_AddWatchpoint_Test_NonNullMessageList(void)
 {
@@ -233,7 +232,7 @@ void LC_CheckMsgForWPs_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_TIME_GetTime, 1);
-} /* end LC_CheckMsgForWPs_Test_Nominal */
+}
 
 void LC_CheckMsgForWPs_Test_NominalMsgTime1(void)
 {
@@ -261,7 +260,7 @@ void LC_CheckMsgForWPs_Test_NominalMsgTime1(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_MID_INF_EID);
     UtAssert_STUB_COUNT(CFE_TIME_GetTime, 0);
-} /* end LC_CheckMsgForWPs_Test_Nominal */
+}
 
 void LC_CheckMsgForWPs_Test_NominalMsgTime2(void)
 {
@@ -298,7 +297,7 @@ void LC_CheckMsgForWPs_Test_NominalMsgTime2(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_WP_OFFSET_ERR_EID);
     UtAssert_STUB_COUNT(CFE_TIME_GetTime, 0);
-} /* end LC_CheckMsgForWPs_Test_Nominal */
+}
 
 void LC_CheckMsgForWPs_Test_NominalDisabled(void)
 {
@@ -314,7 +313,7 @@ void LC_CheckMsgForWPs_Test_NominalDisabled(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_TIME_GetTime, 0);
-} /* end LC_CheckMsgForWPs_Test_NominalDisabled */
+}
 
 void LC_CheckMsgForWPs_Test_UnreferencedMessageID(void)
 {
@@ -338,8 +337,7 @@ void LC_CheckMsgForWPs_Test_UnreferencedMessageID(void)
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_CheckMsgForWPs_Test_UnreferencedMessageID */
+}
 
 void LC_ProcessWP_Test_CustomFunctionWatchFalse(void)
 {
@@ -375,7 +373,7 @@ void LC_ProcessWP_Test_CustomFunctionWatchFalse(void)
     /* Note: this event message is generated in a subfunction, but is tested anyway to verify that the correct code path
      * has been reached */
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
-} /* end LC_ProcessWP_Test_CustomFunctionWatchFalse */
+}
 
 void LC_ProcessWP_Test_OperatorCompareError(void)
 {
@@ -406,8 +404,7 @@ void LC_ProcessWP_Test_OperatorCompareError(void)
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end LC_ProcessWP_Test_OperatorCompareError */
+}
 
 void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale(void)
 {
@@ -456,8 +453,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale(void)
                   "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds == 5");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale */
+}
 
 void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousFalse(void)
 {
@@ -506,8 +502,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousFalse(void)
                   "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds == 5");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale */
+}
 
 void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
 {
@@ -553,8 +548,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
                   "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds == 5");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale */
+}
 
 void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousTrue(void)
 {
@@ -600,8 +594,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousTrue(void)
                   "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds == 5");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale */
+}
 
 void LC_ProcessWP_Test_BadSize(void)
 {
@@ -737,8 +730,7 @@ void LC_OperatorCompare_Test_DataByte(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataByte */
+}
 
 void LC_OperatorCompare_Test_DataWordLE(void)
 {
@@ -761,8 +753,7 @@ void LC_OperatorCompare_Test_DataWordLE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataWordLE */
+}
 
 void LC_OperatorCompare_Test_DataDWordLE(void)
 {
@@ -785,8 +776,7 @@ void LC_OperatorCompare_Test_DataDWordLE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataDWordLE */
+}
 
 void LC_OperatorCompare_Test_DataUByte(void)
 {
@@ -809,8 +799,7 @@ void LC_OperatorCompare_Test_DataUByte(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataUByte */
+}
 
 void LC_OperatorCompare_Test_DataUWordLE(void)
 {
@@ -833,8 +822,7 @@ void LC_OperatorCompare_Test_DataUWordLE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataUWordLE */
+}
 
 void LC_OperatorCompare_Test_DataUDWordLE(void)
 {
@@ -857,8 +845,7 @@ void LC_OperatorCompare_Test_DataUDWordLE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataUDWordLE */
+}
 
 void LC_OperatorCompare_Test_DataFloatLE(void)
 {
@@ -881,8 +868,7 @@ void LC_OperatorCompare_Test_DataFloatLE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_OperatorCompare_Test_DataFloatLE */
+}
 
 void LC_OperatorCompare_Test_DataTypeError(void)
 {
@@ -917,8 +903,7 @@ void LC_OperatorCompare_Test_DataTypeError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_OperatorCompare_Test_DataTypeError */
+}
 
 void LC_SignedCompare_Test_LE(void)
 {
@@ -936,8 +921,7 @@ void LC_SignedCompare_Test_LE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_SignedCompare_Test_LE */
+}
 
 void LC_SignedCompare_Test_LT(void)
 {
@@ -955,8 +939,7 @@ void LC_SignedCompare_Test_LT(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_SignedCompare_Test_LT */
+}
 
 void LC_SignedCompare_Test_EQ(void)
 {
@@ -974,8 +957,7 @@ void LC_SignedCompare_Test_EQ(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_SignedCompare_Test_EQ */
+}
 
 void LC_SignedCompare_Test_NE(void)
 {
@@ -993,8 +975,7 @@ void LC_SignedCompare_Test_NE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_SignedCompare_Test_NE */
+}
 
 void LC_SignedCompare_Test_GT(void)
 {
@@ -1012,8 +993,7 @@ void LC_SignedCompare_Test_GT(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_SignedCompare_Test_GT */
+}
 
 void LC_SignedCompare_Test_GE(void)
 {
@@ -1031,8 +1011,7 @@ void LC_SignedCompare_Test_GE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_SignedCompare_Test_GE */
+}
 
 void LC_SignedCompare_Test_InvalidOperatorID(void)
 {
@@ -1062,8 +1041,7 @@ void LC_SignedCompare_Test_InvalidOperatorID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_SignedCompare_Test_InvalidOperatorID */
+}
 
 void LC_UnsignedCompare_Test_LE(void)
 {
@@ -1081,8 +1059,7 @@ void LC_UnsignedCompare_Test_LE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_UnsignedCompare_Test_LE */
+}
 
 void LC_UnsignedCompare_Test_LT(void)
 {
@@ -1100,8 +1077,7 @@ void LC_UnsignedCompare_Test_LT(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_UnsignedCompare_Test_LT */
+}
 
 void LC_UnsignedCompare_Test_EQ(void)
 {
@@ -1119,8 +1095,7 @@ void LC_UnsignedCompare_Test_EQ(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_UnsignedCompare_Test_EQ */
+}
 
 void LC_UnsignedCompare_Test_NE(void)
 {
@@ -1138,8 +1113,7 @@ void LC_UnsignedCompare_Test_NE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_UnsignedCompare_Test_NE */
+}
 
 void LC_UnsignedCompare_Test_GT(void)
 {
@@ -1157,8 +1131,7 @@ void LC_UnsignedCompare_Test_GT(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_UnsignedCompare_Test_GT */
+}
 
 void LC_UnsignedCompare_Test_GE(void)
 {
@@ -1176,8 +1149,7 @@ void LC_UnsignedCompare_Test_GE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_UnsignedCompare_Test_GE */
+}
 
 void LC_UnsignedCompare_Test_InvalidOperatorID(void)
 {
@@ -1206,8 +1178,7 @@ void LC_UnsignedCompare_Test_InvalidOperatorID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_UnsignedCompare_Test_InvalidOperatorID */
+}
 
 void LC_FloatCompare_Test_LE(void)
 {
@@ -1228,8 +1199,7 @@ void LC_FloatCompare_Test_LE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_LE */
+}
 
 void LC_FloatCompare_Test_LT(void)
 {
@@ -1250,8 +1220,7 @@ void LC_FloatCompare_Test_LT(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_LT */
+}
 
 void LC_FloatCompare_Test_EQ(void)
 {
@@ -1272,8 +1241,7 @@ void LC_FloatCompare_Test_EQ(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_EQ */
+}
 
 void LC_FloatCompare_Test_EQFail(void)
 {
@@ -1294,8 +1262,7 @@ void LC_FloatCompare_Test_EQFail(void)
     UtAssert_True(Result == LC_WATCH_FALSE, "Result == LC_WATCH_FALSE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_EQ */
+}
 
 void LC_FloatCompare_Test_NE(void)
 {
@@ -1316,8 +1283,7 @@ void LC_FloatCompare_Test_NE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_NE */
+}
 
 void LC_FloatCompare_Test_NEFail(void)
 {
@@ -1338,8 +1304,7 @@ void LC_FloatCompare_Test_NEFail(void)
     UtAssert_True(Result == LC_WATCH_FALSE, "Result == LC_WATCH_FALSE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_NE */
+}
 
 void LC_FloatCompare_Test_GT(void)
 {
@@ -1360,8 +1325,7 @@ void LC_FloatCompare_Test_GT(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_GT */
+}
 
 void LC_FloatCompare_Test_GE(void)
 {
@@ -1382,8 +1346,7 @@ void LC_FloatCompare_Test_GE(void)
     UtAssert_True(Result == LC_WATCH_TRUE, "Result == LC_WATCH_TRUE");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_FloatCompare_Test_GE */
+}
 
 void LC_FloatCompare_Test_InvalidOperatorID(void)
 {
@@ -1415,8 +1378,7 @@ void LC_FloatCompare_Test_InvalidOperatorID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_FloatCompare_Test_InvalidOperatorID */
+}
 
 void LC_FloatCompare_Test_NaN(void)
 {
@@ -1449,8 +1411,7 @@ void LC_FloatCompare_Test_NaN(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_FloatCompare_Test_NaN */
+}
 
 void LC_WPOffsetValid_Test_DataUByte(void)
 {
@@ -1475,8 +1436,7 @@ void LC_WPOffsetValid_Test_DataUByte(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_WPOffsetValid_Test_DataUByte */
+}
 
 void LC_WPOffsetValid_Test_UWordLE(void)
 {
@@ -1501,8 +1461,7 @@ void LC_WPOffsetValid_Test_UWordLE(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_WPOffsetValid_Test_UWordLE */
+}
 
 void LC_WPOffsetValid_Test_UDWordLE(void)
 {
@@ -1527,8 +1486,7 @@ void LC_WPOffsetValid_Test_UDWordLE(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_WPOffsetValid_Test_UDWordLE */
+}
 
 void LC_WPOffsetValid_Test_FloatLE(void)
 {
@@ -1552,8 +1510,7 @@ void LC_WPOffsetValid_Test_FloatLE(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_WPOffsetValid_Test_FloatLE */
+}
 
 void LC_WPOffsetValid_Test_DataTypeError(void)
 {
@@ -1590,8 +1547,7 @@ void LC_WPOffsetValid_Test_DataTypeError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_WPOffsetValid_Test_DataTypeError */
+}
 
 void LC_WPOffsetValid_Test_OffsetError(void)
 {
@@ -1631,8 +1587,7 @@ void LC_WPOffsetValid_Test_OffsetError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_WPOffsetValid_Test_OffsetError */
+}
 
 void LC_GetSizedWPData_Test_DataByte(void)
 {
@@ -1656,8 +1611,7 @@ void LC_GetSizedWPData_Test_DataByte(void)
     UtAssert_True(SizedData == 1, "SizedData == 1");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataByte */
+}
 
 void LC_GetSizedWPData_Test_DataUByte(void)
 {
@@ -1681,8 +1635,7 @@ void LC_GetSizedWPData_Test_DataUByte(void)
     UtAssert_True(SizedData == 1, "SizedData == 1");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataUByte */
+}
 
 void LC_GetSizedWPData_Test_DataWordBELittleEndian(void)
 {
@@ -1706,8 +1659,7 @@ void LC_GetSizedWPData_Test_DataWordBELittleEndian(void)
     UtAssert_True(SizedData == 0x0102, "SizedData == 0x0102");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataWordBELittleEndian */
+}
 
 void LC_GetSizedWPData_Test_DataWordLELittleEndian(void)
 {
@@ -1731,8 +1683,7 @@ void LC_GetSizedWPData_Test_DataWordLELittleEndian(void)
     UtAssert_True(SizedData == 0x0201, "SizedData == 0x0201");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataWordLELittleEndian */
+}
 
 void LC_GetSizedWPData_Test_DataUWordBELittleEndian(void)
 {
@@ -1756,8 +1707,7 @@ void LC_GetSizedWPData_Test_DataUWordBELittleEndian(void)
     UtAssert_True(SizedData == 0x0102, "SizedData == 0x0102");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataUWordBELittleEndian */
+}
 
 void LC_GetSizedWPData_Test_DataUWordLELittleEndian(void)
 {
@@ -1781,8 +1731,7 @@ void LC_GetSizedWPData_Test_DataUWordLELittleEndian(void)
     UtAssert_True(SizedData == 0x0201, "SizedData == 0x0201");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataUWordLELittleEndian */
+}
 
 void LC_GetSizedWPData_Test_DataFloatBELittleEndian(void)
 {
@@ -1806,8 +1755,7 @@ void LC_GetSizedWPData_Test_DataFloatBELittleEndian(void)
     UtAssert_True(SizedData == 0x01020304, "SizedData == 0x01020304");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataFloatBELittleEndian */
+}
 
 void LC_GetSizedWPData_Test_DataFloatLELittleEndian(void)
 {
@@ -1831,8 +1779,7 @@ void LC_GetSizedWPData_Test_DataFloatLELittleEndian(void)
     UtAssert_True(SizedData == 0x04030201, "SizedData == 0x04030201");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_GetSizedWPData_Test_DataFloatLELittleEndian */
+}
 
 void LC_GetSizedWPData_Test_DataTypeError(void)
 {
@@ -1871,8 +1818,7 @@ void LC_GetSizedWPData_Test_DataTypeError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_GetSizedWPData_Test_DataTypeError */
+}
 
 void LC_ValidateWDT_Test_UnusedTableEntry(void)
 {
@@ -1902,8 +1848,7 @@ void LC_ValidateWDT_Test_UnusedTableEntry(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ValidateWDT_Test_UnusedTableEntry */
+}
 
 void LC_ValidateWDT_Test_AllDataTypes(void)
 {
@@ -1959,8 +1904,7 @@ void LC_ValidateWDT_Test_AllDataTypes(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string 2 matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_UnusedTableEntry */
+}
 
 void LC_ValidateWDT_Test_AllOperatorIDs(void)
 {
@@ -2012,8 +1956,7 @@ void LC_ValidateWDT_Test_AllOperatorIDs(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string 2 matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_UnusedTableEntry */
+}
 
 void LC_ValidateWDT_Test_InvalidDataType(void)
 {
@@ -2056,8 +1999,7 @@ void LC_ValidateWDT_Test_InvalidDataType(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_InvalidDataType */
+}
 
 void LC_ValidateWDT_Test_InvalidOperator(void)
 {
@@ -2099,8 +2041,7 @@ void LC_ValidateWDT_Test_InvalidOperator(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_InvalidOperator */
+}
 
 void LC_ValidateWDT_Test_BadMessageID(void)
 {
@@ -2142,8 +2083,7 @@ void LC_ValidateWDT_Test_BadMessageID(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_BadMessageID */
+}
 
 void LC_ValidateWDT_Test_NaN(void)
 {
@@ -2184,8 +2124,7 @@ void LC_ValidateWDT_Test_NaN(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_NaN */
+}
 
 void LC_ValidateWDT_Test_Inf(void)
 {
@@ -2227,8 +2166,7 @@ void LC_ValidateWDT_Test_Inf(void)
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end LC_ValidateWDT_Test_Inf */
+}
 
 void LC_ValidateWDT_Test_FloatingPointPassed(void)
 {
@@ -2261,8 +2199,7 @@ void LC_ValidateWDT_Test_FloatingPointPassed(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ValidateWDT_Test_FloatingPointPassed */
+}
 
 void LC_ValidateWDT_Test_NonFloatingPointPassed(void)
 {
@@ -2295,8 +2232,7 @@ void LC_ValidateWDT_Test_NonFloatingPointPassed(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end LC_ValidateWDT_Test_NonFloatingPointPassed */
+}
 
 void LC_ValidateWDT_Test_FloatBE(void)
 {
@@ -2342,8 +2278,7 @@ void LC_Uint32IsNAN_Test_True(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_Uint32IsNAN_Test_True */
+}
 
 void LC_Uint32IsNAN_Test_False(void)
 {
@@ -2356,8 +2291,7 @@ void LC_Uint32IsNAN_Test_False(void)
     UtAssert_True(Result == false, "Result == false");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_Uint32IsNAN_Test_False */
+}
 
 void LC_Uint32IsInfinite_Test_True(void)
 {
@@ -2370,8 +2304,7 @@ void LC_Uint32IsInfinite_Test_True(void)
     UtAssert_True(Result == true, "Result == true");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_Uint32IsInfinite_Test_True */
+}
 
 void LC_Uint32IsInfinite_Test_False(void)
 {
@@ -2384,8 +2317,7 @@ void LC_Uint32IsInfinite_Test_False(void)
     UtAssert_True(Result == false, "Result == false");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_Uint32IsInfinite_Test_False */
+}
 
 void LC_Uint32IsInfinite_Test_False2(void)
 {
@@ -2398,8 +2330,7 @@ void LC_Uint32IsInfinite_Test_False2(void)
     UtAssert_True(Result == false, "Result == false");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-
-} /* end LC_Uint32IsInfinite_Test_False2 */
+}
 
 void UtTest_Setup(void)
 {
@@ -2542,6 +2473,3 @@ void UtTest_Setup(void)
 
     UtTest_Add(LC_Uint32IsInfinite_Test_False2, LC_Test_Setup, LC_Test_TearDown, "LC_Uint32IsInfinite_Test_False2");
 }
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/stubs/lc_app_stubs.c
+++ b/unit-test/stubs/lc_app_stubs.c
@@ -74,7 +74,6 @@ int32 LC_AppInit(void)
  */
 void LC_AppMain(void)
 {
-
     UT_GenStub_Execute(LC_AppMain, Basic, NULL);
 }
 

--- a/unit-test/stubs/lc_cmds_stubs.c
+++ b/unit-test/stubs/lc_cmds_stubs.c
@@ -123,7 +123,6 @@ void LC_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
  */
 void LC_ResetCounters(void)
 {
-
     UT_GenStub_Execute(LC_ResetCounters, Basic, NULL);
 }
 

--- a/unit-test/stubs/lc_utils_stubs.c
+++ b/unit-test/stubs/lc_utils_stubs.c
@@ -96,13 +96,13 @@ int32 LC_UpdateTaskCDS(void)
  */
 bool LC_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 {
-    // UT_GenStub_SetupReturnBuffer(LC_VerifyMsgLength, bool);
+    /* UT_GenStub_SetupReturnBuffer(LC_VerifyMsgLength, bool); */
 
-    // UT_GenStub_AddParam(LC_VerifyMsgLength, const CFE_MSG_Message_t* , MsgPtr);
-    // UT_GenStub_AddParam(LC_VerifyMsgLength, size_t , ExpectedLength);
+    /* UT_GenStub_AddParam(LC_VerifyMsgLength, const CFE_MSG_Message_t* , MsgPtr); */
+    /* UT_GenStub_AddParam(LC_VerifyMsgLength, size_t , ExpectedLength); */
 
-    // UT_GenStub_Execute(LC_VerifyMsgLength, Basic, NULL);
+    /* UT_GenStub_Execute(LC_VerifyMsgLength, Basic, NULL); */
 
-    // return UT_GenStub_GetReturnValue(LC_VerifyMsgLength, bool);
+    /* return UT_GenStub_GetReturnValue(LC_VerifyMsgLength, bool); */
     return UT_DEFAULT_IMPL(LC_VerifyMsgLength) != 0;
 }

--- a/unit-test/stubs/lc_watch_stubs.c
+++ b/unit-test/stubs/lc_watch_stubs.c
@@ -84,7 +84,6 @@ void LC_CheckMsgForWPs(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
  */
 void LC_CreateHashTable(void)
 {
-
     UT_GenStub_Execute(LC_CreateHashTable, Basic, NULL);
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #43
Removes redundant and inconsistent comments (e.g. `/* end of function */`)
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 