### PR TITLE
Fix #45, Apply consistent Event ID names to common events

### DIFF
--- a/config/default_lc_fcncodes.h
+++ b/config/default_lc_fcncodes.h
@@ -57,7 +57,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -79,7 +79,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdCount will be cleared
- *       - The #LC_RESET_DBG_EID debug event message will be
+ *       - The #LC_RESET_INF_EID debug event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -88,7 +88,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -121,7 +121,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *       - Error specific event message #LC_LCSTATE_ERR_EID
  *
  *  \par Criticality
@@ -157,7 +157,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *       - Error specific event message #LC_APSTATE_NEW_ERR_EID
  *       - Error specific event message #LC_APSTATE_APNUM_ERR_EID
  *       - Error specific event message #LC_APSTATE_CURR_ERR_EID
@@ -193,7 +193,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *       - Error specific event message #LC_APOFF_APNUM_ERR_EID
  *       - Error specific event message #LC_APOFF_CURR_ERR_EID
  *
@@ -227,7 +227,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *       - Error specific event message #LC_APSTATS_APNUM_ERR_EID
  *
  *  \par Criticality
@@ -261,7 +261,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #LC_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #LC_LEN_ERR_EID
+ *       - Error specific event message #LC_CMD_LEN_ERR_EID
  *       - Error specific event message #LC_WPSTATS_WPNUM_ERR_EID
  *
  *  \par Criticality

--- a/fsw/inc/lc_eventids.h
+++ b/fsw/inc/lc_eventids.h
@@ -394,14 +394,14 @@
 /**
  * \brief LC Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  This event message is issued when a reset counters command has
  *  been received.
  */
-#define LC_RESET_DBG_EID 27
+#define LC_RESET_INF_EID 27
 
 /**
  * \brief LC Set Limit Checker State Command Event ID
@@ -596,7 +596,7 @@
  *  This event message is issued when a ground command message is received
  *  with a message length that doesn't match the expected value.
  */
-#define LC_LEN_ERR_EID 43
+#define LC_CMD_LEN_ERR_EID 43
 
 /**
  * \brief LC Watchpoint Message Unsubscribe Failed Event ID

--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -280,7 +280,7 @@ void LC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     LC_ResetCounters();
 
-    CFE_EVS_SendEvent(LC_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(LC_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/lc_dispatch.c
+++ b/fsw/src/lc_dispatch.c
@@ -82,7 +82,7 @@ bool LC_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
                 /*
                 ** All other cases, increment error counter
                 */
-                CFE_EVS_SendEvent(LC_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(LC_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
                                   (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
                                   (int)ExpectedLength);

--- a/unit-test/lc_dispatch_tests.c
+++ b/unit-test/lc_dispatch_tests.c
@@ -133,7 +133,7 @@ void LC_AppPipe_Test_Noop(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_NoopCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -157,7 +157,7 @@ void LC_AppPipe_Test_Reset(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_ResetCountersCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -181,7 +181,7 @@ void LC_AppPipe_Test_SetLCState(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_SetLCStateCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -207,7 +207,7 @@ void LC_AppPipe_Test_SetAPState(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_SetAPStateCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -231,7 +231,7 @@ void LC_AppPipe_Test_SetAPPermOff(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_SetAPPermOffCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -255,7 +255,7 @@ void LC_AppPipe_Test_ResetAPStats(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_ResetAPStatsCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -279,7 +279,7 @@ void LC_AppPipe_Test_ResetWPStats(void)
     /* Verify handler NOT called again */
     UtAssert_STUB_COUNT(LC_ResetWPStatsCmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #45 
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt