### PR TITLE
Fix #14, Refactor LC_SampleAPs to remove extraneous if statement

### DIFF
--- a/fsw/src/lc_action.c
+++ b/fsw/src/lc_action.c
@@ -44,39 +44,28 @@ void LC_SampleAPs(uint16 StartIndex, uint16 EndIndex)
     uint8  CurrentAPState;
 
     /*
-    ** If we're specifying a single actionpoint, make sure it's
-    ** current state is valid for a sample request
+    ** Make sure the current state of the starting actionpoint
+    ** in the sample is valid for a sample request
     */
-    if (StartIndex == EndIndex)
-    {
-        CurrentAPState = LC_OperData.ARTPtr[StartIndex].CurrentState;
+    CurrentAPState = LC_OperData.ARTPtr[StartIndex].CurrentState;
 
-        if ((CurrentAPState != LC_APSTATE_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
+    if ((CurrentAPState != LC_ACTION_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
+    {
+        /*
+         ** Sample selected actionpoints
+         */
+        for (TableIndex = StartIndex; TableIndex <= EndIndex; TableIndex++)
         {
-            /*
-            ** Sample the specified actionpoint
-            */
-            LC_SampleSingleAP(StartIndex);
-        }
-        else
-        {
-            /*
-            **  Actionpoint isn't currently operational
-            */
-            CFE_EVS_SendEvent(LC_APSAMPLE_CURR_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Sample AP error, invalid current AP state: AP = %d, State = %d", StartIndex,
-                              CurrentAPState);
+            LC_SampleSingleAP(TableIndex);
         }
     }
     else
     {
         /*
-        ** Sample selected actionpoints
+        **  Actionpoint isn't currently operational
         */
-        for (TableIndex = StartIndex; TableIndex <= EndIndex; TableIndex++)
-        {
-            LC_SampleSingleAP(TableIndex);
-        }
+        CFE_EVS_SendEvent(LC_APSAMPLE_CURR_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Sample AP error, invalid current AP state: AP = %d, State = %d", StartIndex, CurrentAPState);
     }
 
     return;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #14 
  - `LC_SampleAPs()` has been refactored to remove the extraneous `if` statement.
  - Action points are still sampled in the same way, and if `StartIndex == EndIndex`, the `for` loop will only run once (i.e. the same as before).

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Intent of the code remains basically unchanged, although the logic has changed slightly.
Main change is that `CurrentAPState` is checked as valid before any sampling of action points, whereas previously this was only checked in the single action point sample condition - i.e. `if (StartIndex == EndIndex)`

**Contributor Info**
Avi @thnkslprpt