### PR TITLE
Fix #49, Move variables declared mid-function to the top

### DIFF
--- a/unit-test/lc_action_tests.c
+++ b/unit-test/lc_action_tests.c
@@ -1685,12 +1685,13 @@ void LC_ValidateRPN_Test_StackDepthZero2(void)
 
 void LC_ValidateRPN_Test_MaxRPNSize(void)
 {
+    int   i;
     uint8 Result;
 
     int32 IndexValue      = 0;
     int32 StackDepthValue = 0;
 
-    for (int i = 0; i < LC_MAX_RPN_EQU_SIZE; i++)
+    for (i = 0; i < LC_MAX_RPN_EQU_SIZE; i++)
     {
         LC_OperData.ADTPtr[0].RPNEquation[i] = LC_MAX_WATCHPOINTS - 1;
     }

--- a/unit-test/lc_app_tests.c
+++ b/unit-test/lc_app_tests.c
@@ -1343,11 +1343,10 @@ void LC_CreateTaskCDS_Test_Nominal(void)
 void LC_CreateTaskCDS_Test_WRTRegisterCDSError(void)
 {
     int32 Result;
-
-    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, -1);
-
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, -1);
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error registering WRT CDS Area, RC=0x%%08X");
 
@@ -1367,11 +1366,10 @@ void LC_CreateTaskCDS_Test_WRTRegisterCDSError(void)
 void LC_CreateTaskCDS_Test_ARTRegisterCDSError(void)
 {
     int32 Result;
-
-    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 2, -1);
-
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 2, -1);
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error registering ART CDS Area, RC=0x%%08X");
 
@@ -1391,11 +1389,10 @@ void LC_CreateTaskCDS_Test_ARTRegisterCDSError(void)
 void LC_CreateTaskCDS_Test_AppDataRegisterCDSError(void)
 {
     int32 Result;
-
-    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 3, -1);
-
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 3, -1);
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error registering application data CDS Area, RC=0x%%08X");

--- a/unit-test/lc_cmds_tests.c
+++ b/unit-test/lc_cmds_tests.c
@@ -131,6 +131,8 @@ void LC_SampleAPReq_Test_ArrayIndexOutOfRange(void)
 {
     CFE_SB_MsgId_t         TestMsgId;
     LC_SampleAP_Payload_t *PayloadPtr = &UT_CmdBuf.SampleAPCmd.Payload;
+    int32                  strCmpResult;
+    char                   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_SAMPLE_AP_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -138,9 +140,6 @@ void LC_SampleAPReq_Test_ArrayIndexOutOfRange(void)
     LC_AppData.CurrentLCState = 99;
     PayloadPtr->StartIndex    = 2;
     PayloadPtr->EndIndex      = 1;
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Sample AP error: invalid AP number, start = %%d, end = %%d");
@@ -163,12 +162,11 @@ void LC_SampleAPReq_Test_BadSampleAllArgs(void)
 {
     CFE_SB_MsgId_t         TestMsgId;
     LC_SampleAP_Payload_t *PayloadPtr = &UT_CmdBuf.SampleAPCmd.Payload;
+    int32                  strCmpResult;
+    char                   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_SAMPLE_AP_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Sample AP error: invalid AP number, start = %%d, end = %%d");
@@ -196,12 +194,11 @@ void LC_SampleAPReq_Test_ArrayEndIndexTooHigh(void)
 {
     CFE_SB_MsgId_t         TestMsgId;
     LC_SampleAP_Payload_t *PayloadPtr = &UT_CmdBuf.SampleAPCmd.Payload;
+    int32                  strCmpResult;
+    char                   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_SAMPLE_AP_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Sample AP error: invalid AP number, start = %%d, end = %%d");
@@ -876,12 +873,11 @@ void LC_SetLCStateCmd_Test_Active(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetLCState_Payload_t *PayloadPtr = &UT_CmdBuf.SetLCStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set LC state command: new state = %%d");
 
@@ -908,12 +904,11 @@ void LC_SetLCStateCmd_Test_Passive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetLCState_Payload_t *PayloadPtr = &UT_CmdBuf.SetLCStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set LC state command: new state = %%d");
 
@@ -940,12 +935,11 @@ void LC_SetLCStateCmd_Test_Disabled(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetLCState_Payload_t *PayloadPtr = &UT_CmdBuf.SetLCStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set LC state command: new state = %%d");
 
@@ -972,12 +966,11 @@ void LC_SetLCStateCmd_Test_Default(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetLCState_Payload_t *PayloadPtr = &UT_CmdBuf.SetLCStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set LC state error: invalid state = %%d");
 
@@ -1003,12 +996,11 @@ void LC_SetAPStateCmd_Test_Default(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state error: AP = %%d, Invalid new state = %%d");
@@ -1037,12 +1029,11 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActive(void)
     uint16                   TableIndex;
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1090,12 +1081,11 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOneNotUsed(void)
     uint16                   TableIndex;
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1144,12 +1134,11 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOnePermOff(void)
     uint16                   TableIndex;
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1198,12 +1187,11 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsPassive(void)
     uint16                   TableIndex;
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1251,12 +1239,11 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsDisabled(void)
     uint16                   TableIndex;
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1303,12 +1290,11 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointActive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1339,12 +1325,11 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointNotUsed(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state error: AP = %%d, Invalid current AP state = %%d");
@@ -1375,12 +1360,11 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointPassive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1411,12 +1395,11 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointDisabled(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state command: AP = %%d, New state = %%d");
@@ -1447,12 +1430,11 @@ void LC_SetAPStateCmd_Test_InvalidCurrentAPStateActive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state error: AP = %%d, Invalid current AP state = %%d");
@@ -1482,12 +1464,11 @@ void LC_SetAPStateCmd_Test_InvalidCurrentAPStatePassive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state error: AP = %%d, Invalid current AP state = %%d");
@@ -1517,12 +1498,11 @@ void LC_SetAPStateCmd_Test_InvalidCurrentAPStateDisabled(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP state error: AP = %%d, Invalid current AP state = %%d");
@@ -1553,12 +1533,11 @@ void LC_SetAPStateCmd_Test_InvalidAPNumberActive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set AP state error: Invalid AP number = %%d");
 
@@ -1587,12 +1566,11 @@ void LC_SetAPStateCmd_Test_InvalidAPNumberPassive(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set AP state error: Invalid AP number = %%d");
 
@@ -1620,12 +1598,11 @@ void LC_SetAPStateCmd_Test_InvalidAPNumberDisabled(void)
 {
     CFE_SB_MsgId_t           TestMsgId;
     LC_SetAPState_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPStateCmd.Payload;
+    int32                    strCmpResult;
+    char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set AP state error: Invalid AP number = %%d");
 
@@ -1652,12 +1629,11 @@ void LC_SetAPPermOffCmd_Test_InvalidAPNumberMaxActionpoints(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_SetAPPermOff_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPPermOffCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set AP perm off error: Invalid AP number = %%d");
 
@@ -1682,12 +1658,11 @@ void LC_SetAPPermOffCmd_Test_InvalidAPNumberAllActionpoints(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_SetAPPermOff_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPPermOffCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set AP perm off error: Invalid AP number = %%d");
 
@@ -1712,12 +1687,11 @@ void LC_SetAPPermOffCmd_Test_APNotDisabled(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_SetAPPermOff_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPPermOffCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Set AP perm off error, AP NOT Disabled: AP = %%d, Current state = %%d");
@@ -1745,12 +1719,11 @@ void LC_SetAPPermOffCmd_Test_Nominal(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_SetAPPermOff_Payload_t *PayloadPtr = &UT_CmdBuf.SetAPPermOffCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Set AP permanently off command: AP = %%d");
 
@@ -1779,12 +1752,11 @@ void LC_ResetAPStatsCmd_Test_AllActionPoints(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_ResetAPStats_Payload_t *PayloadPtr = &UT_CmdBuf.ResetAPStatsCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset AP stats command: AP = %%d");
 
@@ -1809,12 +1781,11 @@ void LC_ResetAPStatsCmd_Test_SingleActionPoint(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_ResetAPStats_Payload_t *PayloadPtr = &UT_CmdBuf.ResetAPStatsCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset AP stats command: AP = %%d");
 
@@ -1839,12 +1810,11 @@ void LC_ResetAPStatsCmd_Test_InvalidAPNumber(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_ResetAPStats_Payload_t *PayloadPtr = &UT_CmdBuf.ResetAPStatsCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset AP stats error: invalid AP number = %%d");
 
@@ -1970,12 +1940,11 @@ void LC_ResetWPStatsCmd_Test_AllWatchPoints(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_ResetWPStats_Payload_t *PayloadPtr = &UT_CmdBuf.ResetWPStatsCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset WP stats command: WP = %%d");
 
@@ -2000,12 +1969,11 @@ void LC_ResetWPStatsCmd_Test_SingleWatchPoint(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_ResetWPStats_Payload_t *PayloadPtr = &UT_CmdBuf.ResetWPStatsCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset WP stats command: WP = %%d");
 
@@ -2029,12 +1997,11 @@ void LC_ResetWPStatsCmd_Test_InvalidWPNumber(void)
 {
     CFE_SB_MsgId_t             TestMsgId;
     LC_ResetWPStats_Payload_t *PayloadPtr = &UT_CmdBuf.ResetWPStatsCmd.Payload;
+    int32                      strCmpResult;
+    char                       ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset WP stats error: invalid WP number = %%d");
 

--- a/unit-test/lc_utils_tests.c
+++ b/unit-test/lc_utils_tests.c
@@ -40,6 +40,8 @@ uint8 call_count_CFE_EVS_SendEvent;
 void LC_ManageTables_Test_Nominal(void)
 {
     int32 Result;
+    uint8 call_count_LC_ResetResultsWP;
+    uint8 call_count_LC_ResetResultsAP;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
 
@@ -52,8 +54,8 @@ void LC_ManageTables_Test_Nominal(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
 
-    uint8 call_count_LC_ResetResultsWP = UT_GetStubCount(UT_KEY(LC_ResetResultsWP));
-    uint8 call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
+    call_count_LC_ResetResultsWP = UT_GetStubCount(UT_KEY(LC_ResetResultsWP));
+    call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsWP, 0);
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 0);
@@ -62,6 +64,8 @@ void LC_ManageTables_Test_Nominal(void)
 void LC_ManageTables_Test_InfoUpdated(void)
 {
     int32 Result;
+    uint8 call_count_LC_ResetResultsWP;
+    uint8 call_count_LC_ResetResultsAP;
 
     /* Set to satisfy all instances of condition "Result == CFE_TBL_INFO_UPDATED" */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
@@ -75,8 +79,8 @@ void LC_ManageTables_Test_InfoUpdated(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
 
-    uint8 call_count_LC_ResetResultsWP = UT_GetStubCount(UT_KEY(LC_ResetResultsWP));
-    uint8 call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
+    call_count_LC_ResetResultsWP = UT_GetStubCount(UT_KEY(LC_ResetResultsWP));
+    call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsWP, 1);
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 1);
@@ -87,6 +91,8 @@ void LC_ManageTables_Test_WDTGetAddressError(void)
     int32 Result;
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    uint8 call_count_LC_ResetResultsWP;
+    uint8 call_count_LC_ResetResultsAP;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error getting WDT address, RC=0x%%08X");
 
@@ -107,8 +113,8 @@ void LC_ManageTables_Test_WDTGetAddressError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    uint8 call_count_LC_ResetResultsWP = UT_GetStubCount(UT_KEY(LC_ResetResultsWP));
-    uint8 call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
+    call_count_LC_ResetResultsWP = UT_GetStubCount(UT_KEY(LC_ResetResultsWP));
+    call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsWP, 0);
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 0);
@@ -119,6 +125,7 @@ void LC_ManageTables_Test_ADTGetAddressError(void)
     int32 Result;
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    uint8 call_count_LC_ResetResultsAP;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error getting ADT address, RC=0x%%08X");
 
@@ -139,7 +146,7 @@ void LC_ManageTables_Test_ADTGetAddressError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    uint8 call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
+    call_count_LC_ResetResultsAP = UT_GetStubCount(UT_KEY(LC_ResetResultsAP));
 
     UtAssert_INT32_EQ(call_count_LC_ResetResultsAP, 0);
 }

--- a/unit-test/lc_watch_tests.c
+++ b/unit-test/lc_watch_tests.c
@@ -500,11 +500,10 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
 {
     uint16             WatchIndex = 0;
     CFE_TIME_SysTime_t Timestamp;
+    CFE_SB_MsgId_t     TestMsgId = LC_UT_MID_1;
 
     Timestamp.Seconds    = 3;
     Timestamp.Subseconds = 5;
-
-    CFE_SB_MsgId_t TestMsgId = LC_UT_MID_1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -544,11 +543,10 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousTrue(void)
 {
     uint16             WatchIndex = 0;
     CFE_TIME_SysTime_t Timestamp;
+    CFE_SB_MsgId_t     TestMsgId = LC_UT_MID_1;
 
     Timestamp.Seconds    = 3;
     Timestamp.Subseconds = 5;
-
-    CFE_SB_MsgId_t TestMsgId = LC_UT_MID_1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -612,10 +610,10 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousTrue(void)
 {
     uint16             WatchIndex = 0;
     CFE_TIME_SysTime_t Timestamp;
+    CFE_SB_MsgId_t     TestMsgId = LC_UT_MID_1;
 
-    Timestamp.Seconds        = 3;
-    Timestamp.Subseconds     = 5;
-    CFE_SB_MsgId_t TestMsgId = LC_UT_MID_1;
+    Timestamp.Seconds    = 3;
+    Timestamp.Subseconds = 5;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -655,11 +653,10 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousFalse(void)
 {
     uint16             WatchIndex = 0;
     CFE_TIME_SysTime_t Timestamp;
+    CFE_SB_MsgId_t     TestMsgId = LC_UT_MID_1;
 
     Timestamp.Seconds    = 3;
     Timestamp.Subseconds = 5;
-
-    CFE_SB_MsgId_t TestMsgId = LC_UT_MID_1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -857,6 +854,8 @@ void LC_OperatorCompare_Test_DataTypeError(void)
     uint8  Result;
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
+    int32  strCmpResult;
+    char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     LC_OperData.WDTPtr[WatchIndex].DataType                = 99;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_LE;
@@ -865,9 +864,6 @@ void LC_OperatorCompare_Test_DataTypeError(void)
     LC_OperData.WDTPtr[WatchIndex].BitMask                 = 0;
     LC_OperData.WDTPtr[WatchIndex].ComparisonValue.Float32 = 1.0;
     LC_OperData.WRTPtr[WatchIndex].EvaluationCount         = 0;
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP has undefined data type: WP = %%d, DataType = %%d");
@@ -1001,11 +997,10 @@ void LC_SignedCompare_Test_InvalidOperatorID(void)
     uint16 WatchIndex   = 0;
     int32  WPValue      = 1;
     int32  CompareValue = 0;
+    int32  strCmpResult;
+    char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     LC_OperData.WDTPtr[WatchIndex].OperatorID = 99;
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP has invalid operator ID: WP = %%d, OperID = %%d");
@@ -1336,13 +1331,13 @@ void LC_FloatCompare_Test_InvalidOperatorID(void)
     uint16         WatchIndex = 0;
     LC_MultiType_t WPMultiType;
     LC_MultiType_t CompareMultiType;
+    int32          strCmpResult;
+    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     WPMultiType.Float32      = 1.0;
     CompareMultiType.Float32 = 0.0;
 
     LC_OperData.WDTPtr[WatchIndex].OperatorID = 99;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP has invalid operator ID: WP = %%d, OperID = %%d");
@@ -1368,12 +1363,12 @@ void LC_FloatCompare_Test_NaN(void)
     uint16         WatchIndex = 0;
     LC_MultiType_t WPMultiType;
     LC_MultiType_t CompareMultiType;
+    int32          strCmpResult;
+    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     WPMultiType.Float32      = 1.0;
     WPMultiType.Unsigned32   = 0x7F8FFFFF;
     CompareMultiType.Float32 = 0.0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP data value is a float NAN: WP = %%d, Value = 0x%%08X");
@@ -1400,10 +1395,10 @@ void LC_WPOffsetValid_Test_DataUByte(void)
     bool           Result;
     uint16         WatchIndex = 0;
     CFE_SB_MsgId_t TestMsgId  = LC_UT_MID_1;
+    size_t         MsgSize    = 16;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    size_t MsgSize = 16;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UBYTE;
@@ -1423,10 +1418,10 @@ void LC_WPOffsetValid_Test_UWordLE(void)
     bool           Result;
     uint16         WatchIndex = 0;
     CFE_SB_MsgId_t TestMsgId  = LC_UT_MID_1;
+    size_t         MsgSize    = 16;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    size_t MsgSize = 16;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UWORD_LE;
@@ -1446,10 +1441,10 @@ void LC_WPOffsetValid_Test_UDWordLE(void)
     bool           Result;
     uint16         WatchIndex = 0;
     CFE_SB_MsgId_t TestMsgId  = LC_UT_MID_1;
+    size_t         MsgSize    = 16;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    size_t MsgSize = 16;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UDWORD_LE;
@@ -1469,9 +1464,10 @@ void LC_WPOffsetValid_Test_FloatLE(void)
     bool           Result;
     uint16         WatchIndex = 0;
     CFE_SB_MsgId_t TestMsgId  = LC_UT_MID_1;
+    size_t         MsgSize    = 16;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    size_t MsgSize = 16;
+
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_FLOAT_LE;
@@ -1491,11 +1487,10 @@ void LC_WPOffsetValid_Test_DataTypeError(void)
     bool           Result;
     uint16         WatchIndex = 0;
     CFE_SB_MsgId_t TestMsgId  = LC_UT_MID_1;
+    int32          strCmpResult;
+    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP has undefined data type: WP = %%d, DataType = %%d");
@@ -1527,13 +1522,13 @@ void LC_WPOffsetValid_Test_OffsetError(void)
     bool           Result;
     uint16         WatchIndex = 0;
     CFE_SB_MsgId_t TestMsgId  = LC_UT_MID_1;
+    size_t         MsgSize    = 0;
+    int32          strCmpResult;
+    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    size_t MsgSize = 0;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP offset error: MID = 0x%%08lX, WP = %%d, Offset = %%d, DataSize = %%d, MsgLen = %%d");
@@ -1828,11 +1823,10 @@ void LC_ValidateWDT_Test_AllDataTypes(void)
     int32 TableIndex;
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    char  ExpectedEventString2[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WDT verify err: WP = %%d, Err = %%d, DType = %%d, Oper = %%d, MID = 0x%%08lX");
-
-    char ExpectedEventString2[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WDT verify results: good = %%d, bad = %%d, unused = %%d");
@@ -1885,11 +1879,10 @@ void LC_ValidateWDT_Test_AllOperatorIDs(void)
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    char  ExpectedEventString2[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WDT verify err: WP = %%d, Err = %%d, DType = %%d, Oper = %%d, MID = 0x%%08lX");
-
-    char ExpectedEventString2[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WDT verify results: good = %%d, bad = %%d, unused = %%d");


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #49
  - All of the variables that were declared mid-function were moved to the top of their respective functions.

In LC these were all in test code, nevertheless consistency is worth applying across the board.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
All variables declared top of function as per cFS conventions/guidelines.

**Contributor Info**
Avi Weiss @thnkslprpt