### PR TITLE
Fix #51, externalize symbols in lc_test_utils.h

### DIFF
--- a/unit-test/utilities/lc_test_utils.c
+++ b/unit-test/utilities/lc_test_utils.c
@@ -34,6 +34,11 @@
 #include "utassert.h"
 #include "utstubs.h"
 
+LC_WDTEntry_t WDTable[LC_MAX_WATCHPOINTS];
+LC_ADTEntry_t ADTable[LC_MAX_ACTIONPOINTS];
+LC_WRTEntry_t WRTable[LC_MAX_WATCHPOINTS];
+LC_ARTEntry_t ARTable[LC_MAX_ACTIONPOINTS];
+
 #define UT_MAX_SENDEVENT_DEPTH 4
 CFE_EVS_SendEvent_context_t    context_CFE_EVS_SendEvent[UT_MAX_SENDEVENT_DEPTH];
 CFE_ES_WriteToSysLog_context_t context_CFE_ES_WriteToSysLog;

--- a/unit-test/utilities/lc_test_utils.h
+++ b/unit-test/utilities/lc_test_utils.h
@@ -36,10 +36,10 @@ extern LC_AppData_t  LC_AppData;
 extern LC_OperData_t LC_OperData;
 
 /* Global table variables for table pointers contained in LC_OperData */
-LC_WDTEntry_t WDTable[LC_MAX_WATCHPOINTS];
-LC_ADTEntry_t ADTable[LC_MAX_ACTIONPOINTS];
-LC_WRTEntry_t WRTable[LC_MAX_WATCHPOINTS];
-LC_ARTEntry_t ARTable[LC_MAX_ACTIONPOINTS];
+extern LC_WDTEntry_t WDTable[LC_MAX_WATCHPOINTS];
+extern LC_ADTEntry_t ADTable[LC_MAX_ACTIONPOINTS];
+extern LC_WRTEntry_t WRTable[LC_MAX_WATCHPOINTS];
+extern LC_ARTEntry_t ARTable[LC_MAX_ACTIONPOINTS];
 
 /*
  * Global context structures


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Make the table objects in this header "extern" and instantiate them in the C file instead.  This solves the duplicate symbol linker errors.

Fixes #51

**Testing performed**
Build and run all tests

**Expected behavior changes**
Tests will build, link, and execute successfully

**System(s) tested on**
Ubuntu 22.04

**Additional context**
Will submit a separate issue to consider adding `-fno-common` to the CFS CI workflows, as it masks this issue in Ubuntu 20.04.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
