### PR TITLE
Fix #66, correct buffer overflows in UT

### DIFF
--- a/unit-test/lc_action_tests.c
+++ b/unit-test/lc_action_tests.c
@@ -230,7 +230,7 @@ void LC_SampleSingleAP_Test_ActiveRequestRTS(void)
 
     LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS    = 5;
     LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount = LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS;
-    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", 50);
+    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", sizeof(LC_OperData.ADTPtr[APNumber].EventText));
 
     /* Execute the function being tested */
     LC_SampleSingleAP(APNumber);
@@ -274,7 +274,7 @@ void LC_SampleSingleAP_Test_APFailWhileLCStatePassive(void)
 
     LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS    = 5;
     LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount = LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS;
-    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", 50);
+    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", sizeof(LC_OperData.ADTPtr[APNumber].EventText));
 
     /* Execute the function being tested */
     LC_SampleSingleAP(APNumber);
@@ -318,7 +318,7 @@ void LC_SampleSingleAP_Test_APFailWhilePassive(void)
 
     LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS    = 5;
     LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount = LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS;
-    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", 50);
+    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", sizeof(LC_OperData.ADTPtr[APNumber].EventText));
 
     LC_OperData.ADTPtr[APNumber].MaxPassiveEvents = 5;
     LC_OperData.ARTPtr[APNumber].PassiveAPCount   = LC_OperData.ADTPtr[APNumber].MaxPassiveEvents - 1;
@@ -363,7 +363,7 @@ void LC_SampleSingleAP_Test_APFailWhilePassiveNoEvent(void)
 
     LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS    = 5;
     LC_OperData.ARTPtr[APNumber].ConsecutiveFailCount = LC_OperData.ADTPtr[APNumber].MaxFailsBeforeRTS;
-    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", 50);
+    strncpy(LC_OperData.ADTPtr[APNumber].EventText, "Event Message", sizeof(LC_OperData.ADTPtr[APNumber].EventText));
 
     LC_OperData.ADTPtr[APNumber].MaxPassiveEvents = 5;
     LC_OperData.ARTPtr[APNumber].PassiveAPCount   = LC_OperData.ADTPtr[APNumber].MaxPassiveEvents + 1;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The default size of the "EventText" string is 32, but the unit test had hard coded string sizes of 50 chars, which will overflow the buffer.

Use "sizeof" operator to adjust to the actual size of the destination to correct the issue.

Fixes #66

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
No more buffer overflow

**System(s) tested on**
Debian Bookworm

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

