### PR TITLE
Fix #57, NaN check

### DIFF
--- a/fsw/src/lc_watch.h
+++ b/fsw/src/lc_watch.h
@@ -314,44 +314,6 @@ bool LC_WPOffsetValid(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr);
 bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedDataPtr);
 
 /**
- * \brief Check uint32 for float NAN
- *
- *  \par Description
- *       Utility function for watchpoint processing that will test if
- *       a uint32 value would result in a NAN (not-a-number) value if
- *       it was interpreted as a float.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param [in]  Data     The uint32 value to check
- *
- *  \return Boolean is a float NAN result
- *  \retval true Value is a float NAN
- *  \retval false Value is not a float NAN
- */
-bool LC_Uint32IsNAN(uint32 Data);
-
-/**
- * \brief Check uint32 for float infinite
- *
- *  \par Description
- *       Utility function for watchpoint processing that will test if
- *       a uint32 value would result in an infinite value if
- *       it was interpreted as a float.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param [in]  Data     The uint32 value to check
- *
- *  \return Boolean is a float infinite result
- *  \retval true Value is an inifinite float
- *  \retval valse Value is not an inifinite float
- */
-bool LC_Uint32IsInfinite(uint32 Data);
-
-/**
  * \brief Convert messageID into hash table index
  *
  *  \par Description

--- a/unit-test/lc_watch_tests.c
+++ b/unit-test/lc_watch_tests.c
@@ -2267,71 +2267,6 @@ void LC_ValidateWDT_Test_FloatBE(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 }
 
-void LC_Uint32IsNAN_Test_True(void)
-{
-    bool Result;
-
-    /* Execute the function being tested */
-    Result = LC_Uint32IsNAN(0x7F8FFFFF);
-
-    /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
-
-    UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-}
-
-void LC_Uint32IsNAN_Test_False(void)
-{
-    bool Result;
-
-    /* Execute the function being tested */
-    Result = LC_Uint32IsNAN(0x10000000);
-
-    /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
-    UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-}
-
-void LC_Uint32IsInfinite_Test_True(void)
-{
-    bool Result;
-
-    /* Execute the function being tested */
-    Result = LC_Uint32IsInfinite(0x7F800000);
-
-    /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
-
-    UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-}
-
-void LC_Uint32IsInfinite_Test_False(void)
-{
-    bool Result;
-
-    /* Execute the function being tested */
-    Result = LC_Uint32IsInfinite(0x10000000);
-
-    /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
-    UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-}
-
-void LC_Uint32IsInfinite_Test_False2(void)
-{
-    bool Result;
-
-    /* Execute the function being tested */
-    Result = LC_Uint32IsInfinite(0x7F800002);
-
-    /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
-    UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
-}
-
 void UtTest_Setup(void)
 {
     UtTest_Add(LC_CreateHashTable_Test, LC_Test_Setup, LC_Test_TearDown, "LC_CreateHashTable_Test");
@@ -2464,12 +2399,4 @@ void UtTest_Setup(void)
                "LC_ValidateWDT_Test_AllOperatorIDs");
 
     UtTest_Add(LC_ValidateWDT_Test_FloatBE, LC_Test_Setup, LC_Test_TearDown, "LC_ValidateWDT_Test_FloatBE");
-
-    UtTest_Add(LC_Uint32IsNAN_Test_True, LC_Test_Setup, LC_Test_TearDown, "LC_Uint32IsNAN_Test_True");
-    UtTest_Add(LC_Uint32IsNAN_Test_False, LC_Test_Setup, LC_Test_TearDown, "LC_Uint32IsNAN_Test_False");
-
-    UtTest_Add(LC_Uint32IsInfinite_Test_True, LC_Test_Setup, LC_Test_TearDown, "LC_Uint32IsInfinite_Test_True");
-    UtTest_Add(LC_Uint32IsInfinite_Test_False, LC_Test_Setup, LC_Test_TearDown, "LC_Uint32IsInfinite_Test_False");
-
-    UtTest_Add(LC_Uint32IsInfinite_Test_False2, LC_Test_Setup, LC_Test_TearDown, "LC_Uint32IsInfinite_Test_False2");
 }

--- a/unit-test/stubs/lc_watch_stubs.c
+++ b/unit-test/stubs/lc_watch_stubs.c
@@ -190,38 +190,6 @@ uint8 LC_SignedCompare(uint16 WatchIndex, int32 WPValue, int32 CompareValue)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for LC_Uint32IsInfinite()
- * ----------------------------------------------------
- */
-bool LC_Uint32IsInfinite(uint32 Data)
-{
-    UT_GenStub_SetupReturnBuffer(LC_Uint32IsInfinite, bool);
-
-    UT_GenStub_AddParam(LC_Uint32IsInfinite, uint32, Data);
-
-    UT_GenStub_Execute(LC_Uint32IsInfinite, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(LC_Uint32IsInfinite, bool);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for LC_Uint32IsNAN()
- * ----------------------------------------------------
- */
-bool LC_Uint32IsNAN(uint32 Data)
-{
-    UT_GenStub_SetupReturnBuffer(LC_Uint32IsNAN, bool);
-
-    UT_GenStub_AddParam(LC_Uint32IsNAN, uint32, Data);
-
-    UT_GenStub_Execute(LC_Uint32IsNAN, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(LC_Uint32IsNAN, bool);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for LC_UnsignedCompare()
  * ----------------------------------------------------
  */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Use C99 standard math.h macros to check for NaN and/or infinity.

Note that in addition to being platform independent, in an optimized build this will likely invoke a much more efficient CPU instruction to do the test as opposed to the bit-masking that was done before.

Fixes #57

**Testing performed**
Build and run all tests

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Debian

**Additional context**
C99 provides standardized macros for these NaN/Infinity checks in `math.h`

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
