### PR TITLE
Fix #72, correct use of union type

### DIFF
--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -851,36 +851,36 @@ bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedD
     switch (LC_OperData.WDTPtr[WatchIndex].DataType)
     {
         case LC_DATA_BYTE:
-            TempBuffer.Unsigned8 = *WPDataPtr;
-            ConvBuffer.Signed32  = TempBuffer.Signed8; /* Extend signed 8 bit value to 32 bits */
+            TempBuffer.Signed8 = *WPDataPtr;
+            *SizedDataPtr      = TempBuffer.Signed8; /* Extend signed 8 bit value to 32 bits */
             break;
 
         case LC_DATA_UBYTE:
-            ConvBuffer.Unsigned32 = *WPDataPtr; /* Extend unsigned 8 bit value to 32 bits */
+            *SizedDataPtr = *WPDataPtr; /* Extend unsigned 8 bit value to 32 bits */
             break;
 
         case LC_DATA_WORD_BE:
             ConvBuffer.Unsigned16 = LC_16BIT_BE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(int16));
-            ConvBuffer.Signed32 = TempBuffer.Signed16; /* Extend signed 16 bit value to 32 bits */
+            *SizedDataPtr = TempBuffer.Signed16; /* Extend signed 16 bit value to 32 bits */
             break;
 
         case LC_DATA_WORD_LE:
             ConvBuffer.Unsigned16 = LC_16BIT_LE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(int16));
-            ConvBuffer.Signed32 = TempBuffer.Signed16; /* Extend signed 16 bit value to 32 bits */
+            *SizedDataPtr = TempBuffer.Signed16; /* Extend signed 16 bit value to 32 bits */
             break;
 
         case LC_DATA_UWORD_BE:
             ConvBuffer.Unsigned16 = LC_16BIT_BE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint16));
-            ConvBuffer.Unsigned32 = TempBuffer.Unsigned16; /* Extend unsigned 16 bit value to 32 bits */
+            *SizedDataPtr = TempBuffer.Unsigned16; /* Extend unsigned 16 bit value to 32 bits */
             break;
 
         case LC_DATA_UWORD_LE:
             ConvBuffer.Unsigned16 = LC_16BIT_LE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint16));
-            ConvBuffer.Unsigned32 = TempBuffer.Unsigned16; /* Extend unsigned 16 bit value to 32 bits */
+            *SizedDataPtr = TempBuffer.Unsigned16; /* Extend unsigned 16 bit value to 32 bits */
             break;
 
         case LC_DATA_DWORD_BE:
@@ -888,7 +888,7 @@ bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedD
         case LC_DATA_FLOAT_BE:
             ConvBuffer.Unsigned32 = LC_32BIT_BE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint32));
-            ConvBuffer.Unsigned32 = TempBuffer.Unsigned32; /* Straight copy - no extension (signed or unsigned) */
+            *SizedDataPtr = TempBuffer.Unsigned32; /* Straight copy - no extension (signed or unsigned) */
             break;
 
         case LC_DATA_DWORD_LE:
@@ -896,7 +896,7 @@ bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedD
         case LC_DATA_FLOAT_LE:
             ConvBuffer.Unsigned32 = LC_32BIT_LE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint32));
-            ConvBuffer.Unsigned32 = TempBuffer.Unsigned32; /* Straight copy - no extension (signed or unsigned) */
+            *SizedDataPtr = TempBuffer.Unsigned32; /* Straight copy - no extension (signed or unsigned) */
             break;
 
         default:
@@ -911,20 +911,15 @@ bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedD
             LC_OperData.WRTPtr[WatchIndex].WatchResult      = LC_WATCH_ERROR;
             LC_OperData.WRTPtr[WatchIndex].CountdownToStale = 0;
 
-            Success = false;
+            Success       = false;
+            *SizedDataPtr = 0;
             break;
 
     } /* end switch */
 
     /*
-    ** Set result value
-    */
-    *SizedDataPtr = ConvBuffer.Unsigned32;
-
-    /*
     ** Return success flag
     */
-
     return Success;
 }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Use ISO C standard value conversion, do not rely on platform-dependent union access.

Fixes #72

**Testing performed**
Build and run all tests, confirm `LC_GetSizedWPData()` call is still working as expected.

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
Assigning (by value) between signed and unsigned values is defined by ISO C and results are specified.  In contrast, writing to one union member and reading from another does not have specified results (although on a twos complement machine with typical implementation it happens to produce the same result...)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
