### PR TITLE
Fix #70, update global symbol names for consistency

### DIFF
--- a/docs/dox_src/cfs_lc.dox
+++ b/docs/dox_src/cfs_lc.dox
@@ -49,15 +49,15 @@
 
 /**
   \page cfslcintro CFS Limit Checker Introduction
-	
+
   <H2> Scope </H2>
 
   This document provides a complete specification for the commands and telemetry associated
-  with the CFS Limit Checker (LC) application software.  The document is intended primarily 
-  for users of the software (operations personal, test engineers, and maintenance personnel).  
-  The last section of the document, the deployment guide section, is intended for mission 
-  developers when deploying and configuring the LC application software for a mission 
-  flight software build environment. 
+  with the CFS Limit Checker (LC) application software.  The document is intended primarily
+  for users of the software (operations personal, test engineers, and maintenance personnel).
+  The last section of the document, the deployment guide section, is intended for mission
+  developers when deploying and configuring the LC application software for a mission
+  flight software build environment.
 
   \ref cfslcversion
 
@@ -108,154 +108,154 @@
 /**
   \page cfslcovr CFS Limit Checker Overview
 
-  The CFS Limit Checker (LC) application monitors telemetry data points in the flight system 
-  and compares the values against predefined threshold limits. When a threshold condition 
-  is encountered, an event message is issued and a Relative Time Sequence (RTS) command 
+  The CFS Limit Checker (LC) application monitors telemetry data points in the flight system
+  and compares the values against predefined threshold limits. When a threshold condition
+  is encountered, an event message is issued and a Relative Time Sequence (RTS) command
   script may be initiated to respond to the threshold violation.
 
-  LC is a table driven application. Monitoring and response configuration data is stored in 
-  definition tables that can be updated by the ground operators, while statistics on threshold 
+  LC is a table driven application. Monitoring and response configuration data is stored in
+  definition tables that can be updated by the ground operators, while statistics on threshold
   violations are stored in dump-only results tables and summarized in housekeeping data.
 
-  When processing beyond the standard comparison operators is needed, LC supports the use of 
+  When processing beyond the standard comparison operators is needed, LC supports the use of
   custom evaluation functions that can be modified by a software patch or application update.
 
   \section LC Design Overview
 
-  The LC design is built around two fundamental constructs. The Watchpoint and the 
+  The LC design is built around two fundamental constructs. The Watchpoint and the
   Actionpoint.
 
-  A Watchpoint defines a comparison between a piece of telemetry data and a pre-defined 
-  constant. Watchpoints are defined in the Watchpoint Definition Table (WDT). Statistics 
+  A Watchpoint defines a comparison between a piece of telemetry data and a pre-defined
+  constant. Watchpoints are defined in the Watchpoint Definition Table (WDT). Statistics
   on watchpoint evaluations are stored in the Watchpoint Results Table (WRT)
-  (see \ref cfslctbl). Watchpoints are evaluated whenever a message containing the 
+  (see \ref cfslctbl). Watchpoints are evaluated whenever a message containing the
   telemetry point is received over the software bus by LC.
 
-  An Actionpoint defines the response LC will take based upon the current state of one 
-  or more watchpoints. Actionpoints are defined in the Actionpoint Definition Table (ADT). 
+  An Actionpoint defines the response LC will take based upon the current state of one
+  or more watchpoints. Actionpoints are defined in the Actionpoint Definition Table (ADT).
   Statistics on actionpoint evaluations are stored in the Actionpoint Results Table (ART)
   (see \ref cfslctbl). Actionpoints are evaluated whenever LC receives a message with
-  the #LC_SAMPLE_AP_MID message ID. This is not a ground command but an internal message 
+  the #LC_SAMPLE_AP_MID message ID. This is not a ground command but an internal message
   that will normally come from the CFS scheduler (SCH) application.
-  
+
   \image html LC_Context.png "LC Context Diagram"
   \image latex LC_Context.png "LC Context Diagram"
 **/
 
 /**
   \page cfslcopr CFS Limit Checker Operation
-   
-  The CFS Limit Checker has three modes of operation, set by the #LC_SET_LC_STATE_CC ground 
+
+  The CFS Limit Checker has three modes of operation, set by the #LC_SET_LC_STATE_CC ground
   command and echoed in the CurrentLCState housekeeping variable.
-  
-  Active - Active mode is the normal operation mode. In Active mode, the LC task performs 
-           all limit tests defined in the watchpoint definition table and will invoke stored 
-           command sequences if the results of watchpoint evaluations trigger an actionpoint 
+
+  Active - Active mode is the normal operation mode. In Active mode, the LC task performs
+           all limit tests defined in the watchpoint definition table and will invoke stored
+           command sequences if the results of watchpoint evaluations trigger an actionpoint
            condition as defined in the actionpoint definition table.
 
-  Passive - In Passive mode, the LC task behaves just like in Active mode except no stored 
+  Passive - In Passive mode, the LC task behaves just like in Active mode except no stored
             command sequences will be invoked as a result of actionpoint triggers.
 
-  Disabled - When disabled, the LC task will perform no watchpoint or actionpoint limit 
+  Disabled - When disabled, the LC task will perform no watchpoint or actionpoint limit
              tests.
-  
-  Watchpoints are evaluated whenever a message containing the telemetry point is received 
-  by LC. Watchpoints may evaluate to #LC_WATCH_TRUE, #LC_WATCH_FALSE, #LC_WATCH_STALE 
-  or #LC_WATCH_ERROR. Watchpoints can not be individually disabled. The only ways to keep 
-  Watchpoints from being evaluated are to squelch the telemetry packet on which they trigger, 
-  load a WDT that undefines a Watchpoint or disable the entire LC task.  
-  
-  Actionpoints are evaluated whenever LC receives a message with the #LC_SAMPLE_AP_MID message 
+
+  Watchpoints are evaluated whenever a message containing the telemetry point is received
+  by LC. Watchpoints may evaluate to #LC_WATCH_TRUE, #LC_WATCH_FALSE, #LC_WATCH_STALE
+  or #LC_WATCH_ERROR. Watchpoints can not be individually disabled. The only ways to keep
+  Watchpoints from being evaluated are to squelch the telemetry packet on which they trigger,
+  load a WDT that undefines a Watchpoint or disable the entire LC task.
+
+  Actionpoints are evaluated whenever LC receives a message with the #LC_SAMPLE_AP_MID message
   ID. This message contains a parameter indicating which actionpoint to evaluate. A single
   actionpoint can be specified by using the actionpoint ID (0 to #LC_MAX_ACTIONPOINTS). All
   actionpoints can be evaluated by specifying xFFFF as the parameter. There is no way to evaluate
   multiple actionpoints other than ALL within a single message. An Actionpoint defines a logical
-  relationship between one or more Watchpoint results. 
+  relationship between one or more Watchpoint results.
 
-  This logical relationship is defined in the form of a Reverse Polish Notation (RPN) 
-  expression in the actionpoint definition specified in the ADT. The result of this RPN 
+  This logical relationship is defined in the form of a Reverse Polish Notation (RPN)
+  expression in the actionpoint definition specified in the ADT. The result of this RPN
   evaluation is either #LC_ACTION_PASS, #LC_ACTION_FAIL, #LC_ACTION_STALE or
-  #LC_ACTION_ERROR. In the Actionpoint definition, a maximum number of consecutive fails is 
-  specified. If an Actionpoint fails the specified number of times consecutively, LC sends a 
-  request to the Stored Command (SC) application to execute a RTS (Relative Time Sequence) of 
-  commands as a response to this condition. 
-    
-  Actionpoints can be individually enabled/disabled with the #LC_SET_AP_STATE_CC ground 
-  command. The state of an actionpoint may be set to #LC_APSTATE_ACTIVE, #LC_APSTATE_PASSIVE, 
-  or #LC_APSTATE_DISABLED. These states operate in the same way as the application operating 
-  modes described above. #LC_APSTATE_PASSIVE will just disable RTS requests, while 
-  #LC_APSTATE_DISABLED will stop evaluation of the actionpoint all together. An additional 
-  state #LC_APSTATE_PERMOFF which functions the same as #LC_APSTATE_DISABLED but can only 
-  be changed via table load, can be set using the #LC_SET_AP_PERMOFF_CC ground command 
+  #LC_ACTION_ERROR. In the Actionpoint definition, a maximum number of consecutive fails is
+  specified. If an Actionpoint fails the specified number of times consecutively, LC sends a
+  request to the Stored Command (SC) application to execute a RTS (Relative Time Sequence) of
+  commands as a response to this condition.
+
+  Actionpoints can be individually enabled/disabled with the #LC_SET_AP_STATE_CC ground
+  command. The state of an actionpoint may be set to #LC_APSTATE_ACTIVE, #LC_APSTATE_PASSIVE,
+  or #LC_APSTATE_DISABLED. These states operate in the same way as the application operating
+  modes described above. #LC_APSTATE_PASSIVE will just disable RTS requests, while
+  #LC_APSTATE_DISABLED will stop evaluation of the actionpoint all together. An additional
+  state #LC_APSTATE_PERMOFF which functions the same as #LC_APSTATE_DISABLED but can only
+  be changed via table load, can be set using the #LC_SET_AP_PERM_OFF_CC ground command
   (see \ref cfslcfaqs).
-  
+
   An example of this watchpoint/actionpoint relationship is shown in the following
   diagram:
 
   \image html LC_Monitor_Process.png "LC Monitoring Process Example Diagram"
   \image latex LC_Monitor_Process.png "LC Monitoring Process Example Diagram"
 
-  Since LC is a table driven application, it's behavior is dictated by the contents of the 
-  WDT and ADT configuration tables. To change this behavior is simply a matter of loading a 
+  Since LC is a table driven application, it's behavior is dictated by the contents of the
+  WDT and ADT configuration tables. To change this behavior is simply a matter of loading a
   new table with modified parameters. LC will check for any pending table updates whenever
   it processes a housekeeping request. If the table passes validation it will go into
-  effect right away before the next message is read from the software bus. It is not necessary 
-  to disable LC before updating a table, however since the watchpoint and actionpoint definitions 
-  use two separate tables, careful attention needs to be paid to ensure that the tables are 
+  effect right away before the next message is read from the software bus. It is not necessary
+  to disable LC before updating a table, however since the watchpoint and actionpoint definitions
+  use two separate tables, careful attention needs to be paid to ensure that the tables are
   consistent with each other whenever LC is active. For this reason, a mission may choose to
   always disable LC prior to any table updates and then re-enable monitoring.
-    
-  When either the WDT or ADT are updated, the corresponding results table (WRT or ART) is
-  reset to initialization values. 
 
-  Ideally, LC should require no intervention from the ground on a routine basis. Once monitoring 
-  is enabled, it will keep processing data and checking for threshold violations (assuming regular 
-  scheduler input).  
+  When either the WDT or ADT are updated, the corresponding results table (WRT or ART) is
+  reset to initialization values.
+
+  Ideally, LC should require no intervention from the ground on a routine basis. Once monitoring
+  is enabled, it will keep processing data and checking for threshold violations (assuming regular
+  scheduler input).
 **/
 
 /**
   \page cfslcdg  CFS Limit Checker Deployment Guide
-  
-  The first step in deploying the LC application is to size and construct default WDT 
+
+  The first step in deploying the LC application is to size and construct default WDT
   and ADT tables. LC requires these default table images to be on the filesystem when
   the application is started or it will fail to load. These files are required even
   if using the Critical Data Store (CDS) since LC will fall back to these table images
-  if a table restore from CDS fails (which will happen during a power-on reset). Where LC 
-  will look to find these files is dictated by the configuration parameters 
-  #LC_WDT_FILENAME and #LC_ADT_FILENAME. 
-        
-  The size of the WDT and ADT tables is dictated by the configuration parameters    
-  #LC_MAX_WATCHPOINTS and #LC_MAX_ACTIONPOINTS. The total size of either table should 
-  not exceed the cFE size limit for a single buffered table set by the 
+  if a table restore from CDS fails (which will happen during a power-on reset). Where LC
+  will look to find these files is dictated by the configuration parameters
+  #LC_WDT_FILENAME and #LC_ADT_FILENAME.
+
+  The size of the WDT and ADT tables is dictated by the configuration parameters
+  #LC_MAX_WATCHPOINTS and #LC_MAX_ACTIONPOINTS. The total size of either table should
+  not exceed the cFE size limit for a single buffered table set by the
   #CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE parameter. When considering how many watchpoints and
   actionpoints are needed, keep in mind the the entire WDT is sequentially searched
   whenever a message that may contain watchpoints is received. Likewise the entire
   ADT will be processed whenever a #LC_SAMPLE_AP_MID message is received. While it
   is desirable to leave unused entries in both tables for later updates, large tables
-  will increase search time which may be undesirable depending on the telemetry and 
+  will increase search time which may be undesirable depending on the telemetry and
   actionpoint sample rates required. LC defines the performance ID #LC_WDT_SEARCH_PERF_ID
   that can be used to monitor WDT search time. There is not currently a performance
   ID for ADT processing since the actionpoint sample cycle is not dependent on telemetry
-  rates but set by the configuration of the scheduler (SCH) application. 
-    
+  rates but set by the configuration of the scheduler (SCH) application.
+
   Example source code for these tables sized to the default number of watchpoints
   and actionpoints are provided in the files lc_def_wdt.c and lc_def_adt.c.
-    
+
   LC requires a message with the message ID #LC_SAMPLE_AP_MID to sample actionpoints.
   The CFS scheduler application (SCH) needs to be configured to provide this trigger
   message at the desired frequency for actionpoint processing to occur.
-    
-  The function #LC_ExecuteRTS in the file lc_custom.c needs to be reviewed for any 
+
+  The function #LC_ExecuteRTS in the file lc_custom.c needs to be reviewed for any
   modifications that may be needed to properly initiate RTS responses to actionpoint
   failures. This function uses a local declaration of an example stored commanding
   (SC) message structure which was done to allow LC to be compiled independent
-  of any other external application's data structures. A mission may choose to remove 
-  this and use a message structure declared outside LC instead. This also applies to the 
-  #LC_RTS_REQ_MID and #LC_RTS_REQ_CC constants in lc_mission_cfg.h. 
-    
-  If custom functions are to be used, the function #LC_CustomFunction in the file 
-  lc_custom.c needs to modified appropriately (see \ref cfslcfaqs). 
-  
+  of any other external application's data structures. A mission may choose to remove
+  this and use a message structure declared outside LC instead. This also applies to the
+  #LC_RTS_REQ_MID and #LC_RTS_REQ_CC constants in lc_mission_cfg.h.
+
+  If custom functions are to be used, the function #LC_CustomFunction in the file
+  lc_custom.c needs to modified appropriately (see \ref cfslcfaqs).
+
   In the lc_platform_cfg.h file, there are configuration parameters that control use
   of the Critical Data Store (CDS) and the LC operation mode on application
   initialization. The default case is not to use the CDS and to set the application
@@ -266,80 +266,80 @@
   \page cfslctbl CFS Limit Checker Table Definitions
 
   <H2>Watchpoint Definition Table (WDT)</H2>
-      
+
   The structure of a single watchpoint definition is defined by #LC_WDTEntry_t. The WDT is
-  an array of these entries sized by the configuration parameter #LC_MAX_WATCHPOINTS. 
-  The zero based index into this table is used by LC as the Watchpoint ID. 
+  an array of these entries sized by the configuration parameter #LC_MAX_WATCHPOINTS.
+  The zero based index into this table is used by LC as the Watchpoint ID.
 
   <H2>Actionpoint Definition Table (ADT)</H2>
-      
+
   The structure of a single actionpoint definition is defined by #LC_ADTEntry_t. The ADT is
-  an array of these entries sized by the configuration parameter #LC_MAX_ACTIONPOINTS. 
-  The zero based index into this table is used by LC as the Actionpoint ID. 
+  an array of these entries sized by the configuration parameter #LC_MAX_ACTIONPOINTS.
+  The zero based index into this table is used by LC as the Actionpoint ID.
 
   <H2>Watchpoint Results Table (WRT)</H2>
-      
+
   The structure of a single watchpoint results table entry is defined by #LC_WRTEntry_t.
-  The WRT is an array of these entries sized by the configuration parameter 
+  The WRT is an array of these entries sized by the configuration parameter
   #LC_MAX_WATCHPOINTS. The index into this table is the same Watchpoint ID used for the
   corresponding definition table entry.
 
   The timestamp used for the LastFalseToTrue and LastTrueToFalse fields is taken from the
-  header of the message that contained the watchpoint. If the message timestamp is zero, LC 
+  header of the message that contained the watchpoint. If the message timestamp is zero, LC
   will use the time returned by the #CFE_TIME_GetTime function instead.
 
   <H2>Actionpoint Results Table (ART)</H2>
-      
+
   The structure of a single actionpoint results table entry is defined by #LC_ARTEntry_t.
-  The ART is an array of these entries sized by the configuration parameter 
+  The ART is an array of these entries sized by the configuration parameter
   #LC_MAX_ACTIONPOINTS. The index into this table is the same Actionpoint ID used for the
   corresponding definition table entry.
- 
+
   The entire WDT is searched anytime a message is received that may contain watchpoints.
   For this reason, it is important that unused entries are properly marked by setting
-  the WDT parameter DataType to #LC_WATCH_NOT_USED.
-    
+  the WDT parameter DataType to #LC_DATA_WATCH_NOT_USED.
+
   The entire ADT is processed anytime a sample request is received that specifies an
-  actionpoint equal to #LC_ALL_ACTIONPOINTS. For this reason, it is important that unused 
-  entries are properly marked by setting the ADT parameter DefaultState to 
-  #LC_ACTION_NOT_USED.
-     
+  actionpoint equal to #LC_ALL_ACTIONPOINTS. For this reason, it is important that unused
+  entries are properly marked by setting the ADT parameter DefaultState to
+  #LC_APSTATE_NOT_USED.
+
   When either the WDT or ADT are updated, the corresponding results table (WRT or ART) is
-  reset to initialization values. For each entry in the WRT, WatchResult is set to 
-  #LC_WATCH_STALE and all other values are zeroed. For each entry in the ART, 
-  ActionResult is set to #LC_ACTION_STALE, the CurrentState is set to the 
-  value of the actionpoint's DefaultState specified in the ADT, and all other values are 
+  reset to initialization values. For each entry in the WRT, WatchResult is set to
+  #LC_WATCH_STALE and all other values are zeroed. For each entry in the ART,
+  ActionResult is set to #LC_ACTION_STALE, the CurrentState is set to the
+  value of the actionpoint's DefaultState specified in the ADT, and all other values are
   zeroed.  When preparing to update the WDT or WDT, the LC state should be set
   to inactive prior to the update and then set to active after the update is
   completed.
-    
-  These are also the values used (for the entries specified in the command) when the 
+
+  These are also the values used (for the entries specified in the command) when the
   #LC_RESET_AP_STATS_CC or #LC_RESET_WP_STATS_CC ground command is received.
 **/
 
 /**
   \page cfslccons CFS Limit Checker Operational Constraints
-  
-  The LC application requires default WDT and ADT table images to be on the filesystem 
+
+  The LC application requires default WDT and ADT table images to be on the filesystem
   when the application is started or it will fail to load. These files are required even
   if using the Critical Data Store (CDS) since LC will fall back to these table images
-  if a table restore from CDS fails (which will happen during a power-on reset). Where LC 
-  will look to find these files is dictated by the configuration parameters 
-  #LC_WDT_FILENAME and #LC_ADT_FILENAME. 
-  
-  Potential causes for LC to terminate prematurely are an error return from the 
+  if a table restore from CDS fails (which will happen during a power-on reset). Where LC
+  will look to find these files is dictated by the configuration parameters
+  #LC_WDT_FILENAME and #LC_ADT_FILENAME.
+
+  Potential causes for LC to terminate prematurely are an error return from the
   software bus in the application main loop or error return from one of the cFE table
-  services functions when LC tries to do table management (check for updates, dump 
-  requests etc.) during each housekeeping cycle. 
-    
+  services functions when LC tries to do table management (check for updates, dump
+  requests etc.) during each housekeeping cycle.
+
   When using the Critical Data Store (CDS), the results tables and housekeeping data
-  will only be restored if the application was shut down through cFE Executive Services 
-  and exited clean. If this is not the case, default values will be used 
-  (see \ref cfslcfaqs). 
-    
-  Ideally, LC should require no intervention from the ground on a routine basis. Once 
-  monitoring is enabled, it will keep processing data and checking for threshold violations 
-  (assuming regular scheduler input).  
+  will only be restored if the application was shut down through cFE Executive Services
+  and exited clean. If this is not the case, default values will be used
+  (see \ref cfslcfaqs).
+
+  Ideally, LC should require no intervention from the ground on a routine basis. Once
+  monitoring is enabled, it will keep processing data and checking for threshold violations
+  (assuming regular scheduler input).
 **/
 
 /**
@@ -351,16 +351,16 @@
      Watchpoints evaluate to #LC_WATCH_TRUE or #LC_WATCH_FALSE. When the
      the watchpoint is defined which should be the error condition?
   </B> <BR> <BR> <I>
-     Watchpoints evaluate to a boolean True or False. So if you setup a 
-     comparison < 100 any watchpoint value 0 to 99 will evaluate #LC_WATCH_TRUE 
+     Watchpoints evaluate to a boolean True or False. So if you setup a
+     comparison < 100 any watchpoint value 0 to 99 will evaluate #LC_WATCH_TRUE
      and 100+ will be #LC_WATCH_FALSE.
 
-     You want to construct the watchpoint cases so they evaluate True when you 
+     You want to construct the watchpoint cases so they evaluate True when you
      are outside of the acceptable range for a telemetry point. That's why there
-     are cumulative and consecutive true counts in the watchpoint results 
+     are cumulative and consecutive true counts in the watchpoint results
      table, but no corresponding values for False.
-     
-     For some examples, see the file lc_def_wdt.c  
+
+     For some examples, see the file lc_def_wdt.c
   </I>
 
   <B> (Q)
@@ -370,15 +370,15 @@
      Create additional watchpoint definitions that reference the same telemetry
      point but have different comparison values. The watchpoints will be evaluated
      in the order they are listed in the WDT when the monitor point arrives.
-       
+
      Having multiple watchpoints allows different Actionpoints to trigger on
      each watchpoint state (or combination of states).
   </I>
-  
+
   <B> (Q)
      How do I calculate the watchpoint offset?
   </B> <BR> <BR> <I>
-     The offset is a zero based byte offset from the beginning of the message 
+     The offset is a zero based byte offset from the beginning of the message
      (including any headers) to the first byte of the watchpoint data. So for
      a cFE raw command using CCSDS, the offset has to account for the size of
      the cFE command header.
@@ -390,18 +390,18 @@
      All watchpoints are sized to a 32 bit value when extracted from a message.
      The specified bitmask value is then applied (as a bitwise AND operation) before
      the comparison is made or the custom function is called.
-       
+
      When the watchpoint data is sized, data types smaller than 32 bits are
      properly sign or zero extended. For this reason, it is not necessary to
      define a mask for UWORD, WORD or UBYTE, BYTE data types to compare properly.
      Although it's not needed, a properly constructed bit mask will not cause
      a problem for these evaluations either.
-       
-     When you really need to use a bitmask is when monitoring odd sized data 
+
+     When you really need to use a bitmask is when monitoring odd sized data
      (such as a 24 bit sensor reading) or testing data to see if certain bits
      have been set (or cleared).
-       
-     When no bitmask is needed, be sure to use the constant #LC_NO_BITMASK (or it's
+
+     When no bitmask is needed, be sure to use the constant #LC_BITMASK_NONE (or it's
      equivalent value 0xFFFFFFFF) in your WDT tables. Since masking is a bitwise
      AND, setting the bitmask to zero will have the effect of always clearing the
      watchpoint data prior to comparison.
@@ -412,15 +412,15 @@
      data type?
   </B> <BR> <BR> <I>
      One enhancement made to the CFS version of LC is that it will properly byte
-     swap watchpoint data prior to masking and comparison if the byte order of the 
-     data is different than the order used by the processor running LC. This allows 
+     swap watchpoint data prior to masking and comparison if the byte order of the
+     data is different than the order used by the processor running LC. This allows
      LC to monitor telemetry data that might be constructed by instrument or other
-     subsystem processors that use a different byte order. 
+     subsystem processors that use a different byte order.
 
-     LC determines it's byte order using the _STRUCT_HIGH_BIT_FIRST_ and 
-     _STRUCT_LOW_BIT_FIRST_ compiler switches that are set in the cFE header 
-     common_types.h according to the platform designated in the cFE platform 
-     makefile.         
+     LC determines it's byte order using the _STRUCT_HIGH_BIT_FIRST_ and
+     _STRUCT_LOW_BIT_FIRST_ compiler switches that are set in the cFE header
+     common_types.h according to the platform designated in the cFE platform
+     makefile.
   </I>
 
   <B> (Q)
@@ -428,8 +428,8 @@
   </B> <BR> <BR> <I>
      #LC_WATCH_STALE is an initialization value for the Watchpoint
      Results Table. If a watchpoint has this WatchResult then the watchpoint
-     is unused (the DataType in the WDT is set to #LC_WATCH_NOT_USED) or a
-     message that contains the watchpoint has not yet been received by LC and 
+     is unused (the DataType in the WDT is set to #LC_DATA_WATCH_NOT_USED) or a
+     message that contains the watchpoint has not yet been received by LC and
      evaluated.
   </I>
 
@@ -437,14 +437,14 @@
      When would a watchpoint evalute to #LC_WATCH_ERROR?
   </B> <BR> <BR> <I>
      #LC_WATCH_ERROR is a runtime error indicator for watchpoint processing.
-     Such a result should be rare since most of the causes are invalid watchpoint 
+     Such a result should be rare since most of the causes are invalid watchpoint
      parameters that should be caught during validation of the Watchpoint
      Definition Table.
-       
-     One notable exception is for floating point watchpoints when the message 
+
+     One notable exception is for floating point watchpoints when the message
      data is detected to be a floating point NAN (Not-A-Number) that can't
      be relationally compared to any value.
-       
+
      In all cases, an error event detailing the cause of the problem will be
      issued when a WatchResult is set to #LC_WATCH_ERROR.
   </I>
@@ -454,65 +454,65 @@
   </B> <BR> <BR> <I>
      A custom function is a way to do more complicated processing on a watchpoint
      when the standard comparison operators are not adequate.
-       
+
      When the OperatorID in a watchpoint definition is set to #LC_OPER_CUSTOM.
      The function #LC_CustomFunction is called instead of LC doing a comparison.
      #LC_CustomFunction will then return #LC_WATCH_TRUE or #LC_WATCH_FALSE that
      will be used as the WatchResult.
-       
-     Although #LC_CustomFunction is the same entry point for all watchpoints with a 
-     designated custom function operator, a mission can modify the function body 
+
+     Although #LC_CustomFunction is the same entry point for all watchpoints with a
+     designated custom function operator, a mission can modify the function body
      to switch on the watchpoint ID (or CustomFuncArgument specified in the
      watchpoint definition) and branch to as many different sub-functions
      as it needs for watchpoint specific processing.
- 
-     The #LC_CustomFunction stub is in the source file lc_custom.c   
+
+     The #LC_CustomFunction stub is in the source file lc_custom.c
   </I>
 
   <B> (Q)
-     How is the WPResults array in the housekeeping packet (#LC_HkPacket_t) 
+     How is the WPResults array in the housekeeping packet (#LC_HkPacket_t)
      interpreted?
   </B> <BR> <BR> <I>
      The WPResults array is a byte array (aligned to the nearest longword
-     boundary) that contains a packed subset of the current contents of the 
+     boundary) that contains a packed subset of the current contents of the
      Watchpoint Results Table (see #LC_WRTEntry_t).
-       
+
      It allocates 2 bits per watchpoint for the most recent watchpoint
      comparison result. The numerical 2 bit values are defined using the
      following constants:
-       
+
      #LC_HKWR_FALSE, #LC_HKWR_TRUE, #LC_HKWR_ERROR, #LC_HKWR_STALE
-       
-     Ordering (up to #LC_MAX_WATCHPOINTS) is as follows : 
-       
+
+     Ordering (up to #LC_MAX_WATCHPOINTS) is as follows :
+
      Byte 0:(Rwp3, Rwp2, Rwp1, Rwp0), Byte 1:(Rwp7, Rwp6, Rwp5, Rwp4), etc...
- 
+
      The WPResults array is constructed every housekeeping cycle and is not
      effected by the reset counters (#LC_RESET_CC) ground command. It will only
-     get cleared if the Watchpoint Results Table is reset (via a new WDT table 
+     get cleared if the Watchpoint Results Table is reset (via a new WDT table
      load or with a #LC_RESET_WP_STATS_CC ground command)
   </I>
 
   <H1> Actionpoint Questions </H1>
 
   <B> (Q)
-     Actionpoints evaluate to #LC_ACTION_PASS or #LC_ACTION_FAIL. 
+     Actionpoints evaluate to #LC_ACTION_PASS or #LC_ACTION_FAIL.
      How should the RPN expression get constructed so it will evaluate
      to the proper result?
   </B> <BR> <BR> <I>
      Actionpoint RPN expressions are combinations of watchpoint states and
-     logical operators that evaluate to a boolean True or False. 
-       
+     logical operators that evaluate to a boolean True or False.
+
      Just like a watchpoint evaluation of True indicates a parameter outside
      acceptable limits, an AP expression that evaluates True is considered
      to have Failed and will have it's ActionResult set to #LC_ACTION_FAIL.
-       
+
      While the terminology may seem confusing, the key point is to construct
      both watchpoint and actionpoint expressions to define the error condition
      LC is looking for and NOT the normal condition of the spacecraft data
      stream.
-       
-     For some examples, see the file lc_def_adt.c  
+
+     For some examples, see the file lc_def_adt.c
   </I>
 
   <B> (Q)
@@ -520,14 +520,14 @@
   </B> <BR> <BR> <I>
      #LC_ACTION_STALE is an initialization value for the Actionpoint
      Results Table. If an actionpoint has this ActionResult then one of
-     three possible conditions are true: 
-       
-     1) The actionpoint is unused (the DefaultState in the ADT is set to 
-        #LC_ACTION_NOT_USED).
-        
-     2) An actionpoint sample request (#LC_SAMPLE_AP_MID) targeting the AP has not 
+     three possible conditions are true:
+
+     1) The actionpoint is unused (the DefaultState in the ADT is set to
+        #LC_APSTATE_NOT_USED).
+
+     2) An actionpoint sample request (#LC_SAMPLE_AP_MID) targeting the AP has not
         yet been received by LC so the AP has not yet been evaluated.
-          
+
      3) One or more of the watchpoints that this AP depends on (as defined by
         the RPN expression) has a current WatchResult of #LC_WATCH_STALE
         so the AP can't be evaluated.
@@ -537,58 +537,58 @@
      When would a actionpoint evalute to #LC_ACTION_ERROR?
   </B> <BR> <BR> <I>
      #LC_ACTION_ERROR is a runtime error indicator for actionpoint processing.
-     Such a result should be rare since most of the causes are invalid actionpoint 
-     parameters or improperly constructed RPN expressions that should be caught 
+     Such a result should be rare since most of the causes are invalid actionpoint
+     parameters or improperly constructed RPN expressions that should be caught
      during validation of the Actionpoint Definition Table.
-       
-     However, an exception is the case where one or more watchpoints that this 
-     AP depends on (as defined by the RPN expression) has a current WatchResult of 
+
+     However, an exception is the case where one or more watchpoints that this
+     AP depends on (as defined by the RPN expression) has a current WatchResult of
      #LC_WATCH_ERROR. Since the AP can't be evaluated, this will cause the ActionResult
      to be set to #LC_ACTION_ERROR.
-       
+
      In all cases, an error event detailing the cause of the problem will be
      issued when an ActionResult is set to #LC_ACTION_ERROR.
   </I>
 
   <B> (Q)
-     How does the Actionpoint state #LC_APSTATE_PERMOFF differ from 
+     How does the Actionpoint state #LC_APSTATE_PERMOFF differ from
      #LC_APSTATE_DISABLED?
   </B> <BR> <BR> <I>
      The AP state #LC_APSTATE_PERMOFF is intended to provide a way to disable
      an AP so it can not easily be turned back on by mistake. Such actionpoints
-     may not be needed after a seperation sequence or only apply to certain 
-     mission phases. 
-       
+     may not be needed after a seperation sequence or only apply to certain
+     mission phases.
+
      While the two states are treated the same way during actionpoint processing
      (the AP isn't evaluated), there are a few differences.
-       
+
      An AP can't be set to #LC_APSTATE_PERMOFF with the #LC_SET_AP_STATE_CC command,
-     it must be done with the #LC_SET_AP_PERMOFF_CC command.
-       
-     To set an AP to #LC_APSTATE_PERMOFF with the #LC_SET_AP_PERMOFF_CC command, the
+     it must be done with the #LC_SET_AP_PERM_OFF_CC command.
+
+     To set an AP to #LC_APSTATE_PERMOFF with the #LC_SET_AP_PERM_OFF_CC command, the
      current AP state must be #LC_APSTATE_DISABLED.
-       
-     The #LC_SET_AP_PERMOFF_CC command can only be issued for a single actionpoint,
+
+     The #LC_SET_AP_PERM_OFF_CC command can only be issued for a single actionpoint,
      #LC_ALL_ACTIONPOINTS is not valid as an argument for this command.
-       
+
      Once an AP is set to #LC_APSTATE_PERMOFF, it can only be changed with a new ADT
      table load.
   </I>
 
   <B> (Q)
-     How is the APResults array in the housekeeping packet (#LC_HkPacket_t) 
+     How is the APResults array in the housekeeping packet (#LC_HkPacket_t)
      interpreted?
   </B> <BR> <BR> <I>
      The APResults array is a byte array (aligned to the nearest longword
-     boundary) that contains a packed subset of the current contents of the 
+     boundary) that contains a packed subset of the current contents of the
      Actionpoint Results Table (see #LC_ARTEntry_t).
-       
+
      It allocates 4 bits per actionpoint, with 2 bits representing the current
-     state, and 2 bits for the most recent evaluation result. 
-       
+     state, and 2 bits for the most recent evaluation result.
+
      The numerical 2 bit values for current state are defined using the
      following constants:
-       
+
      #LC_HKAR_STATE_NOT_USED, #LC_HKAR_STATE_ACTIVE, #LC_HKAR_STATE_PASSIVE,
      #LC_HKAR_STATE_DISABLED
 
@@ -597,19 +597,19 @@
 
      The numerical 2 bit values for evaluation results are defined using the
      following constants:
-       
+
      #LC_HKAR_PASS, #LC_HKAR_FAIL, #LC_HKAR_ERROR, #LC_HKAR_STALE
-       
-     Ordering (up to #LC_MAX_ACTIONPOINTS) is as follows : 
-       
+
+     Ordering (up to #LC_MAX_ACTIONPOINTS) is as follows :
+
      Byte 0:(Sap1, Rap1, Sap0, Rap0), Byte 1:(Sap3, Rap3, Sap2, Rap2), etc...
- 
+
      The APResults array is constructed every housekeeping cycle and is not
      effected by the reset counters (#LC_RESET_CC) ground command. It will only
-     get cleared if the Actionpoint Results Table is reset (via a new ADT table 
+     get cleared if the Actionpoint Results Table is reset (via a new ADT table
      load or with a #LC_RESET_AP_STATS_CC ground command)
   </I>
-  
+
   <B> (Q)
      Will an RTS get requested more than once if an AP stays in the #LC_ACTION_FAIL
      state?
@@ -617,7 +617,7 @@
      No. Assuming the current state of an actionpoint is #LC_APSTATE_ACTIVE, then
      when the actionpoint fails enough times to trigger an RTS, the state is set
      to #LC_APSTATE_PASSIVE.
-       
+
      In the passive state, the AP will continue to be sampled and statistics
      updated, but no RTS requests will be initiated.
   </I>
@@ -628,7 +628,7 @@
      Not in the current implementation. Transition event messages for actionpoints
      are of type #CFE_EVS_EventType_DEBUG and enabling them will turn on events for all
      actionpoint transitions.
-       
+
      However, it is planned to add event message limits and event message counts
      to the ADT and ART tables that would allow this type of filtering in a future
      version of LC.
@@ -652,51 +652,51 @@
   </I>
 
   <H1> General Questions </H1>
-  
+
   <B> (Q)
      When do results tables get cleared?
   </B> <BR> <BR> <I>
      When either the WDT or ADT are updated, the corresponding results table (WRT or ART) is
-     reset to initialization values. For each entry in the WRT, WatchResult is set to 
-     #LC_WATCH_STALE and all other values are zeroed. For each entry in the ART, 
-     ActionResult is set to #LC_ACTION_STALE, the CurrentState is set to the 
-     value of the actionpoint's DefaultState specified in the ADT, and all other values are 
+     reset to initialization values. For each entry in the WRT, WatchResult is set to
+     #LC_WATCH_STALE and all other values are zeroed. For each entry in the ART,
+     ActionResult is set to #LC_ACTION_STALE, the CurrentState is set to the
+     value of the actionpoint's DefaultState specified in the ADT, and all other values are
      zeroed.
-    
-     These are also the values used (for the entries specified in the command) when the 
+
+     These are also the values used (for the entries specified in the command) when the
      #LC_RESET_AP_STATS_CC or #LC_RESET_WP_STATS_CC ground command is received.
   </I>
-  
+
   <B> (Q)
      Where can I find some examples of watchpoint and actionpoint table definitions?
   </B> <BR> <BR> <I>
      The files lc_def_wdt.c and lc_def_adt.c provide example source code files that can be
      used to build LC tables and contain some sample table entries in the comment blocks.
-       
+
      Since the CFS LC was based upon the LC implementation for LRO, LRO limit checker
      tables may also provide guidance though there are some minor differences in syntax between
-     the two implementations. 
+     the two implementations.
   </I>
 
   <B> (Q)
      When using the CDS, what is restored and when will defaults be used?
   </B> <BR> <BR> <I>
      When the platform configuration parameter LC_SAVE_TO_CDS is defined, LC will attempt to
-     use the critical data store (CDS) to save and restore data across application restarts. 
+     use the critical data store (CDS) to save and restore data across application restarts.
      The data that LC will save are:
-       
+
        - Watchpoint and Actionpoint Definition Tables
        - Watchpoint and Actionpoint Results Tables
        - LC Housekeeping Data
-         
-     While the definition tables only need to be updated in the CDS when new ones are loaded, 
-     it is not practical from a performance standpoint to update the CDS every time the 
+
+     While the definition tables only need to be updated in the CDS when new ones are loaded,
+     it is not practical from a performance standpoint to update the CDS every time the
      housekeeping data or results data changes. For this reason, results tables and housekeeping
-     are only updated in the CDS if the application is shut down by cFE Executive Services and exits 
-     cleanly. When the application starts, it will check a "saved on exit" flag in the data 
+     are only updated in the CDS if the application is shut down by cFE Executive Services and exits
+     cleanly. When the application starts, it will check a "saved on exit" flag in the data
      restored from CDS to see if the data is good. If not, it will be reset to initialization
      values.
-       
+
      The detailed sequence for a CDS restore on application startup (with failure cases) is as
      follows:
 

--- a/fsw/inc/lc_events.h
+++ b/fsw/inc/lc_events.h
@@ -448,7 +448,7 @@
  *
  *  This event message is issued when the #LC_SET_AP_STATE_CC command
  *  has been received and the current actionpoint state is either
- *  #LC_ACTION_NOT_USED or #LC_APSTATE_PERMOFF which can only be changed
+ *  #LC_APSTATE_NOT_USED or #LC_APSTATE_PERMOFF which can only be changed
  *  with a table load.
  */
 #define LC_APSTATE_CURR_ERR_EID 31
@@ -484,7 +484,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when the #LC_SET_AP_PERMOFF_CC command
+ *  This event message is issued when the #LC_SET_AP_PERM_OFF_CC command
  *  has been received with an invalid actionpoint number specified
  */
 #define LC_APOFF_APNUM_ERR_EID 34
@@ -496,7 +496,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when the #LC_SET_AP_PERMOFF_CC command
+ *  This event message is issued when the #LC_SET_AP_PERM_OFF_CC command
  *  has been received and the current actionpoint state is not
  *  #LC_APSTATE_DISABLED
  */
@@ -509,7 +509,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when the #LC_SET_AP_PERMOFF_CC command
+ *  This event message is issued when the #LC_SET_AP_PERM_OFF_CC command
  *  has been successfully executed
  */
 #define LC_APOFF_INF_EID 36
@@ -772,7 +772,7 @@
  *
  *  This event message is issued when the #LC_SAMPLE_AP_MID message
  *  has been received and the current state for the specified
- *  actionpoint state is either #LC_ACTION_NOT_USED or #LC_APSTATE_PERMOFF.
+ *  actionpoint state is either #LC_APSTATE_NOT_USED or #LC_APSTATE_PERMOFF.
  */
 #define LC_APSAMPLE_CURR_ERR_EID 57
 

--- a/fsw/inc/lc_msg.h
+++ b/fsw/inc/lc_msg.h
@@ -87,7 +87,7 @@ typedef struct
 /**
  *  \brief Set AP (Actionpoint) Permanently Off
  *
- *  For command details see #LC_SET_AP_PERMOFF_CC
+ *  For command details see #LC_SET_AP_PERM_OFF_CC
  */
 typedef struct
 {

--- a/fsw/inc/lc_msgdefs.h
+++ b/fsw/inc/lc_msgdefs.h
@@ -56,11 +56,11 @@
  * \name Actionpoint States
  * \{
  */
-#define LC_ACTION_NOT_USED  0xFF /**< \brief Actionpoint unused, not valid command argument */
+#define LC_APSTATE_NOT_USED 0xFF /**< \brief Actionpoint unused, not valid command argument */
 #define LC_APSTATE_ACTIVE   1    /**< \brief Actionpoint state active */
 #define LC_APSTATE_PASSIVE  2    /**< \brief Actionpoint state passive */
 #define LC_APSTATE_DISABLED 3    /**< \brief Actionpoint state disabled */
-#define LC_APSTATE_PERMOFF  4    /**< \brief Actionpoint state permanently off, see #LC_SET_AP_PERMOFF_CC */
+#define LC_APSTATE_PERMOFF  4    /**< \brief Actionpoint state permanently off, see #LC_SET_AP_PERM_OFF_CC */
 /**\}*/
 
 /**
@@ -238,7 +238,7 @@
  *       - Invalid actionpoint state specified in command message
  *       - Actionpoint number specified in command message is
  *         out of range
- *       - Actionpoint current state is either #LC_ACTION_NOT_USED
+ *       - Actionpoint current state is either #LC_APSTATE_NOT_USED
  *         or #LC_APSTATE_PERMOFF
  *
  *  \par Evidence of failure may be found in the following telemetry:
@@ -287,7 +287,7 @@
  *       None
  *
  */
-#define LC_SET_AP_PERMOFF_CC 4
+#define LC_SET_AP_PERM_OFF_CC 4
 
 /**
  * \brief Reset AP Statistics
@@ -358,5 +358,10 @@
 #define LC_RESET_WP_STATS_CC 6
 
 /**\}*/
+
+#ifndef LC_OMIT_DEPRECATED
+#define LC_SET_AP_PERMOFF_CC LC_SET_AP_PERM_OFF_CC
+#define LC_ACTION_NOT_USED   LC_APSTATE_NOT_USED
+#endif
 
 #endif

--- a/fsw/inc/lc_tbldefs.h
+++ b/fsw/inc/lc_tbldefs.h
@@ -49,22 +49,22 @@
  * \name Watchpoint Definition Table (WDT) DataType Enumerated Types
  * \{
  */
-#define LC_WATCH_NOT_USED 0xFF /**< \brief Use for empty entries */
-#define LC_DATA_BYTE      1    /**< \brief 8 bit signed byte */
-#define LC_DATA_UBYTE     2    /**< \brief 8 bit unsigned byte */
-#define LC_DATA_WORD_BE   3    /**< \brief 16 bit signed word big endian byte order */
-#define LC_DATA_WORD_LE   4    /**< \brief 16 bit signed word little endian byte order */
-#define LC_DATA_UWORD_BE  5    /**< \brief 16 bit unsigned word big endian byte order */
-#define LC_DATA_UWORD_LE  6    /**< \brief 16 bit unsigned word little endian byte order */
-#define LC_DATA_DWORD_BE  7    /**< \brief 32 bit signed double word big endian byte order */
-#define LC_DATA_DWORD_LE  8    /**< \brief 32 bit signed double word little endian byte order */
-#define LC_DATA_UDWORD_BE 9    /**< \brief 32 bit unsigned double word big endian byte order */
-#define LC_DATA_UDWORD_LE 10   /**< \brief 32 bit unsigned double word little endian byte order */
-#define LC_DATA_FLOAT_BE                                                   \
+#define LC_DATA_WATCH_NOT_USED  0xFF /**< \brief Use for empty entries */
+#define LC_DATA_WATCH_BYTE      1    /**< \brief 8 bit signed byte */
+#define LC_DATA_WATCH_UBYTE     2    /**< \brief 8 bit unsigned byte */
+#define LC_DATA_WATCH_WORD_BE   3    /**< \brief 16 bit signed word big endian byte order */
+#define LC_DATA_WATCH_WORD_LE   4    /**< \brief 16 bit signed word little endian byte order */
+#define LC_DATA_WATCH_UWORD_BE  5    /**< \brief 16 bit unsigned word big endian byte order */
+#define LC_DATA_WATCH_UWORD_LE  6    /**< \brief 16 bit unsigned word little endian byte order */
+#define LC_DATA_WATCH_DWORD_BE  7    /**< \brief 32 bit signed double word big endian byte order */
+#define LC_DATA_WATCH_DWORD_LE  8    /**< \brief 32 bit signed double word little endian byte order */
+#define LC_DATA_WATCH_UDWORD_BE 9    /**< \brief 32 bit unsigned double word big endian byte order */
+#define LC_DATA_WATCH_UDWORD_LE 10   /**< \brief 32 bit unsigned double word little endian byte order */
+#define LC_DATA_WATCH_FLOAT_BE                                             \
     11 /**< \brief 32 bit single precision IEEE-754 floating point number, \
         *          big endian byte order                                   \
         */
-#define LC_DATA_FLOAT_LE                                                   \
+#define LC_DATA_WATCH_FLOAT_LE                                             \
     12 /**< \brief 32 bit single precision IEEE-754 floating point number, \
         *          little endian byte order                                \
         */
@@ -74,7 +74,7 @@
  * \name Watchpoint Definition Table (WDT) OperatorID Enumerated Types
  * \{
  */
-#define LC_NO_OPER     0xFF /**< \brief Use for empty entries         */
+#define LC_OPER_NONE   0xFF /**< \brief Use for empty entries         */
 #define LC_OPER_LT     1    /**< \brief Less Than (<)                 */
 #define LC_OPER_LE     2    /**< \brief Less Than or Equal To (<=)    */
 #define LC_OPER_NE     3    /**< \brief Not Equal (!=)                */
@@ -88,7 +88,7 @@
  * \name Watchpoint Definition Table (WDT) BitMask Enumerated Types
  * \{
  */
-#define LC_NO_BITMASK 0xFFFFFFFF /**< \brief Use for no masking       */
+#define LC_BITMASK_NONE 0xFFFFFFFF /**< \brief Use for no masking       */
 /**\}*/
 
 /**
@@ -126,7 +126,7 @@
  * \name Watchpoint Definition Table (WDT) Validation Error Enumerated Types
  * \{
  */
-#define LC_WDTVAL_NO_ERR       0 /**< \brief No error                          */
+#define LC_WDTVAL_ERR_NONE     0 /**< \brief No error                          */
 #define LC_WDTVAL_ERR_DATATYPE 1 /**< \brief Invalid DataType                  */
 #define LC_WDTVAL_ERR_OPER     2 /**< \brief Invalid OperatorID                */
 #define LC_WDTVAL_ERR_MID      3 /**< \brief Invalid MessageID                 */
@@ -138,12 +138,35 @@
  * \name Actionpoint Definition Table (ADT) Validation Error Enumerated Types
  * \{
  */
-#define LC_ADTVAL_NO_ERR       0 /**< \brief No error                          */
+#define LC_ADTVAL_ERR_NONE     0 /**< \brief No error                          */
 #define LC_ADTVAL_ERR_DEFSTATE 1 /**< \brief Invalid DefaultState              */
 #define LC_ADTVAL_ERR_RTSID    2 /**< \brief Invalid RTSId                     */
 #define LC_ADTVAL_ERR_FAILCNT  3 /**< \brief MaxFailsBeforeRTS is zero         */
 #define LC_ADTVAL_ERR_EVTTYPE  4 /**< \brief Invalid EventType                 */
 #define LC_ADTVAL_ERR_RPN      5 /**< \brief Invalid Reverse Polish Expression */
 /**\}*/
+
+#ifndef LC_OMIT_DEPRECATED
+
+#define LC_NO_OPER       LC_OPER_NONE
+#define LC_NO_BITMASK    LC_BITMASK_NONE
+#define LC_ADTVAL_NO_ERR LC_ADTVAL_ERR_NONE
+#define LC_WDTVAL_NO_ERR LC_WDTVAL_ERR_NONE
+
+#define LC_DATA_NOT_USED  LC_DATA_WATCH_NOT_USED
+#define LC_DATA_BYTE      LC_DATA_WATCH_BYTE
+#define LC_DATA_UBYTE     LC_DATA_WATCH_UBYTE
+#define LC_DATA_WORD_BE   LC_DATA_WATCH_WORD_BE
+#define LC_DATA_WORD_LE   LC_DATA_WATCH_WORD_LE
+#define LC_DATA_UWORD_BE  LC_DATA_WATCH_UWORD_BE
+#define LC_DATA_UWORD_LE  LC_DATA_WATCH_UWORD_LE
+#define LC_DATA_DWORD_BE  LC_DATA_WATCH_DWORD_BE
+#define LC_DATA_DWORD_LE  LC_DATA_WATCH_DWORD_LE
+#define LC_DATA_UDWORD_BE LC_DATA_WATCH_UDWORD_BE
+#define LC_DATA_UDWORD_LE LC_DATA_WATCH_UDWORD_LE
+#define LC_DATA_FLOAT_BE  LC_DATA_WATCH_FLOAT_BE
+#define LC_DATA_FLOAT_LE  LC_DATA_WATCH_FLOAT_LE
+
+#endif
 
 #endif

--- a/fsw/src/lc_action.c
+++ b/fsw/src/lc_action.c
@@ -51,7 +51,7 @@ void LC_SampleAPs(uint16 StartIndex, uint16 EndIndex)
     {
         CurrentAPState = LC_OperData.ARTPtr[StartIndex].CurrentState;
 
-        if ((CurrentAPState != LC_ACTION_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
+        if ((CurrentAPState != LC_APSTATE_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
         {
             /*
             ** Sample the specified actionpoint
@@ -483,7 +483,7 @@ int32 LC_ValidateADT(void *TableData)
 {
     LC_ADTEntry_t *TableArray = (LC_ADTEntry_t *)TableData;
 
-    int32 EntryResult = LC_ADTVAL_NO_ERR;
+    int32 EntryResult = LC_ADTVAL_ERR_NONE;
     int32 TableResult = CFE_SUCCESS;
     int32 TableIndex;
 
@@ -511,7 +511,7 @@ int32 LC_ValidateADT(void *TableData)
         RPNPtr            = TableArray[TableIndex].RPNEquation;
         EventType         = TableArray[TableIndex].EventType;
 
-        if (DefaultState == LC_ACTION_NOT_USED)
+        if (DefaultState == LC_APSTATE_NOT_USED)
         {
             /*
             ** Unused table entry
@@ -560,7 +560,7 @@ int32 LC_ValidateADT(void *TableData)
             */
             EntryResult = LC_ValidateRPN(RPNPtr, &RPNIndex, &RPNStackDepth);
 
-            if (EntryResult != LC_ADTVAL_NO_ERR)
+            if (EntryResult != LC_ADTVAL_ERR_NONE)
             {
                 BadCount++;
             }
@@ -573,7 +573,7 @@ int32 LC_ValidateADT(void *TableData)
         /*
         ** Generate detailed event for "first" error
         */
-        if ((EntryResult != LC_ADTVAL_NO_ERR) && (TableResult == CFE_SUCCESS))
+        if ((EntryResult != LC_ADTVAL_ERR_NONE) && (TableResult == CFE_SUCCESS))
         {
             if (EntryResult == LC_ADTVAL_ERR_RPN)
             {
@@ -610,7 +610,7 @@ int32 LC_ValidateADT(void *TableData)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 LC_ValidateRPN(const uint16 *RPNPtr, int32 *IndexValue, int32 *StackDepthValue)
 {
-    int32  Result = LC_ADTVAL_NO_ERR;
+    int32  Result = LC_ADTVAL_ERR_NONE;
     int32  BufferIndex;
     int32  StackDepth;
     uint16 BufferItem;
@@ -686,7 +686,7 @@ int32 LC_ValidateRPN(const uint16 *RPNPtr, int32 *IndexValue, int32 *StackDepthV
     */
     if ((BufferItem == LC_RPN_EQUAL) && (StackDepth == 1))
     {
-        Result = LC_ADTVAL_NO_ERR;
+        Result = LC_ADTVAL_ERR_NONE;
     }
     else
     {

--- a/fsw/src/lc_action.h
+++ b/fsw/src/lc_action.h
@@ -163,7 +163,7 @@ uint8 LC_EvaluateRPN(uint16 APNumber);
  *                                  stack depth value if an error is detected
  *
  *  \return Actionpoint definition table reverse polish notation validation status
- *  \retval #LC_ADTVAL_NO_ERR  \copydoc LC_ADTVAL_NO_ERR
+ *  \retval #LC_ADTVAL_ERR_NONE  \copydoc LC_ADTVAL_ERR_NONE
  *  \retval #LC_ADTVAL_ERR_RPN \copydoc LC_ADTVAL_ERR_RPN
  *
  *  \sa #LC_ValidateADT

--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -89,7 +89,7 @@ int32 LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
                     LC_SetAPStateCmd(BufPtr);
                     break;
 
-                case LC_SET_AP_PERMOFF_CC:
+                case LC_SET_AP_PERM_OFF_CC:
                     LC_SetAPPermOffCmd(BufPtr);
                     break;
 
@@ -361,7 +361,7 @@ int32 LC_HousekeepingReq(const CFE_MSG_CommandHeader_t *MsgPtr)
             */
             switch (LC_OperData.ARTPtr[TableIndex + 1].CurrentState)
             {
-                case LC_ACTION_NOT_USED:
+                case LC_APSTATE_NOT_USED:
                     ByteData = LC_HKAR_STATE_NOT_USED << 6;
                     break;
 
@@ -421,7 +421,7 @@ int32 LC_HousekeepingReq(const CFE_MSG_CommandHeader_t *MsgPtr)
             */
             switch (LC_OperData.ARTPtr[TableIndex].CurrentState)
             {
-                case LC_ACTION_NOT_USED:
+                case LC_APSTATE_NOT_USED:
                     ByteData = (ByteData | (LC_HKAR_STATE_NOT_USED << 2));
                     break;
 
@@ -648,7 +648,7 @@ void LC_SetAPStateCmd(const CFE_SB_Buffer_t *BufPtr)
                 {
                     CurrentAPState = LC_OperData.ARTPtr[TableIndex].CurrentState;
 
-                    if ((CurrentAPState != LC_ACTION_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
+                    if ((CurrentAPState != LC_APSTATE_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
                     {
                         LC_OperData.ARTPtr[TableIndex].CurrentState = CmdPtr->NewAPState;
                     }
@@ -666,7 +666,7 @@ void LC_SetAPStateCmd(const CFE_SB_Buffer_t *BufPtr)
                     TableIndex     = CmdPtr->APNumber;
                     CurrentAPState = LC_OperData.ARTPtr[TableIndex].CurrentState;
 
-                    if ((CurrentAPState != LC_ACTION_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
+                    if ((CurrentAPState != LC_APSTATE_NOT_USED) && (CurrentAPState != LC_APSTATE_PERMOFF))
                     {
                         /*
                         ** Update state for single actionpoint specified

--- a/fsw/src/lc_cmds.h
+++ b/fsw/src/lc_cmds.h
@@ -209,7 +209,7 @@ void LC_SetAPStateCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #LC_SET_AP_PERMOFF_CC
+ *  \sa #LC_SET_AP_PERM_OFF_CC
  */
 void LC_SetAPPermOffCmd(const CFE_SB_Buffer_t *BufPtr);
 

--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -105,7 +105,7 @@ void LC_CreateHashTable(void)
     for (WatchPtTblIndex = 0; WatchPtTblIndex < LC_MAX_WATCHPOINTS; WatchPtTblIndex++)
     {
         /* Skip unused watchpoint table entries */
-        if (LC_OperData.WDTPtr[WatchPtTblIndex].DataType != LC_WATCH_NOT_USED)
+        if (LC_OperData.WDTPtr[WatchPtTblIndex].DataType != LC_DATA_WATCH_NOT_USED)
         {
             MessageID = LC_OperData.WDTPtr[WatchPtTblIndex].MessageID;
 
@@ -450,24 +450,24 @@ uint8 LC_OperatorCompare(uint16 WatchIndex, uint32 ProcessedWPData)
      */
     switch (LC_OperData.WDTPtr[WatchIndex].DataType)
     {
-        case LC_DATA_UBYTE:
-        case LC_DATA_BYTE:
+        case LC_DATA_WATCH_UBYTE:
+        case LC_DATA_WATCH_BYTE:
             WatchpointValue.Unsigned8 = ProcessedWPData & 0xFF;
             break;
 
-        case LC_DATA_WORD_BE:
-        case LC_DATA_WORD_LE:
-        case LC_DATA_UWORD_BE:
-        case LC_DATA_UWORD_LE:
+        case LC_DATA_WATCH_WORD_BE:
+        case LC_DATA_WATCH_WORD_LE:
+        case LC_DATA_WATCH_UWORD_BE:
+        case LC_DATA_WATCH_UWORD_LE:
             WatchpointValue.Unsigned16 = ProcessedWPData & 0xFFFF;
             break;
 
-        case LC_DATA_DWORD_BE:
-        case LC_DATA_DWORD_LE:
-        case LC_DATA_UDWORD_BE:
-        case LC_DATA_UDWORD_LE:
-        case LC_DATA_FLOAT_BE:
-        case LC_DATA_FLOAT_LE:
+        case LC_DATA_WATCH_DWORD_BE:
+        case LC_DATA_WATCH_DWORD_LE:
+        case LC_DATA_WATCH_UDWORD_BE:
+        case LC_DATA_WATCH_UDWORD_LE:
+        case LC_DATA_WATCH_FLOAT_BE:
+        case LC_DATA_WATCH_FLOAT_LE:
         default:
             WatchpointValue.Unsigned32 = ProcessedWPData;
             break;
@@ -484,42 +484,42 @@ uint8 LC_OperatorCompare(uint16 WatchIndex, uint32 ProcessedWPData)
         /*
         ** Signed integer types will get sign extended
         */
-        case LC_DATA_BYTE:
+        case LC_DATA_WATCH_BYTE:
             EvalResult = LC_SignedCompare(WatchIndex, WatchpointValue.Signed8, ComparisonValue.Signed8);
             break;
 
-        case LC_DATA_WORD_BE:
-        case LC_DATA_WORD_LE:
+        case LC_DATA_WATCH_WORD_BE:
+        case LC_DATA_WATCH_WORD_LE:
             EvalResult = LC_SignedCompare(WatchIndex, WatchpointValue.Signed16, ComparisonValue.Signed16);
             break;
 
-        case LC_DATA_DWORD_BE:
-        case LC_DATA_DWORD_LE:
+        case LC_DATA_WATCH_DWORD_BE:
+        case LC_DATA_WATCH_DWORD_LE:
             EvalResult = LC_SignedCompare(WatchIndex, WatchpointValue.Signed32, ComparisonValue.Signed32);
             break;
 
         /*
         ** Unsigned integer types will get zero extended
         */
-        case LC_DATA_UBYTE:
+        case LC_DATA_WATCH_UBYTE:
             EvalResult = LC_UnsignedCompare(WatchIndex, WatchpointValue.Unsigned8, ComparisonValue.Unsigned8);
             break;
 
-        case LC_DATA_UWORD_BE:
-        case LC_DATA_UWORD_LE:
+        case LC_DATA_WATCH_UWORD_BE:
+        case LC_DATA_WATCH_UWORD_LE:
             EvalResult = LC_UnsignedCompare(WatchIndex, WatchpointValue.Unsigned16, ComparisonValue.Unsigned16);
             break;
 
-        case LC_DATA_UDWORD_BE:
-        case LC_DATA_UDWORD_LE:
+        case LC_DATA_WATCH_UDWORD_BE:
+        case LC_DATA_WATCH_UDWORD_LE:
             EvalResult = LC_UnsignedCompare(WatchIndex, WatchpointValue.Unsigned32, ComparisonValue.Unsigned32);
             break;
 
         /*
         ** Floating point values are handled separately
         */
-        case LC_DATA_FLOAT_BE:
-        case LC_DATA_FLOAT_LE:
+        case LC_DATA_WATCH_FLOAT_BE:
+        case LC_DATA_WATCH_FLOAT_LE:
             EvalResult = LC_FloatCompare(WatchIndex, &WatchpointValue, &ComparisonValue);
             break;
 
@@ -752,27 +752,27 @@ bool LC_WPOffsetValid(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr)
     */
     switch (LC_OperData.WDTPtr[WatchIndex].DataType)
     {
-        case LC_DATA_BYTE:
-        case LC_DATA_UBYTE:
+        case LC_DATA_WATCH_BYTE:
+        case LC_DATA_WATCH_UBYTE:
             NumOfDataBytes = sizeof(uint8);
             break;
 
-        case LC_DATA_WORD_BE:
-        case LC_DATA_WORD_LE:
-        case LC_DATA_UWORD_BE:
-        case LC_DATA_UWORD_LE:
+        case LC_DATA_WATCH_WORD_BE:
+        case LC_DATA_WATCH_WORD_LE:
+        case LC_DATA_WATCH_UWORD_BE:
+        case LC_DATA_WATCH_UWORD_LE:
             NumOfDataBytes = sizeof(uint16);
             break;
 
-        case LC_DATA_DWORD_BE:
-        case LC_DATA_DWORD_LE:
-        case LC_DATA_UDWORD_BE:
-        case LC_DATA_UDWORD_LE:
+        case LC_DATA_WATCH_DWORD_BE:
+        case LC_DATA_WATCH_DWORD_LE:
+        case LC_DATA_WATCH_UDWORD_BE:
+        case LC_DATA_WATCH_UDWORD_LE:
             NumOfDataBytes = sizeof(uint32);
             break;
 
-        case LC_DATA_FLOAT_BE:
-        case LC_DATA_FLOAT_LE:
+        case LC_DATA_WATCH_FLOAT_BE:
+        case LC_DATA_WATCH_FLOAT_LE:
             NumOfDataBytes = sizeof(float);
             break;
 
@@ -850,50 +850,50 @@ bool LC_GetSizedWPData(uint16 WatchIndex, const uint8 *WPDataPtr, uint32 *SizedD
     */
     switch (LC_OperData.WDTPtr[WatchIndex].DataType)
     {
-        case LC_DATA_BYTE:
+        case LC_DATA_WATCH_BYTE:
             TempBuffer.Unsigned8 = *WPDataPtr;
             ConvBuffer.Signed32  = TempBuffer.Signed8; /* Extend signed 8 bit value to 32 bits */
             break;
 
-        case LC_DATA_UBYTE:
+        case LC_DATA_WATCH_UBYTE:
             ConvBuffer.Unsigned32 = *WPDataPtr; /* Extend unsigned 8 bit value to 32 bits */
             break;
 
-        case LC_DATA_WORD_BE:
+        case LC_DATA_WATCH_WORD_BE:
             ConvBuffer.Unsigned16 = LC_16BIT_BE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(int16));
             ConvBuffer.Signed32 = TempBuffer.Signed16; /* Extend signed 16 bit value to 32 bits */
             break;
 
-        case LC_DATA_WORD_LE:
+        case LC_DATA_WATCH_WORD_LE:
             ConvBuffer.Unsigned16 = LC_16BIT_LE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(int16));
             ConvBuffer.Signed32 = TempBuffer.Signed16; /* Extend signed 16 bit value to 32 bits */
             break;
 
-        case LC_DATA_UWORD_BE:
+        case LC_DATA_WATCH_UWORD_BE:
             ConvBuffer.Unsigned16 = LC_16BIT_BE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint16));
             ConvBuffer.Unsigned32 = TempBuffer.Unsigned16; /* Extend unsigned 16 bit value to 32 bits */
             break;
 
-        case LC_DATA_UWORD_LE:
+        case LC_DATA_WATCH_UWORD_LE:
             ConvBuffer.Unsigned16 = LC_16BIT_LE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint16));
             ConvBuffer.Unsigned32 = TempBuffer.Unsigned16; /* Extend unsigned 16 bit value to 32 bits */
             break;
 
-        case LC_DATA_DWORD_BE:
-        case LC_DATA_UDWORD_BE:
-        case LC_DATA_FLOAT_BE:
+        case LC_DATA_WATCH_DWORD_BE:
+        case LC_DATA_WATCH_UDWORD_BE:
+        case LC_DATA_WATCH_FLOAT_BE:
             ConvBuffer.Unsigned32 = LC_32BIT_BE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint32));
             ConvBuffer.Unsigned32 = TempBuffer.Unsigned32; /* Straight copy - no extension (signed or unsigned) */
             break;
 
-        case LC_DATA_DWORD_LE:
-        case LC_DATA_UDWORD_LE:
-        case LC_DATA_FLOAT_LE:
+        case LC_DATA_WATCH_DWORD_LE:
+        case LC_DATA_WATCH_UDWORD_LE:
+        case LC_DATA_WATCH_FLOAT_LE:
             ConvBuffer.Unsigned32 = LC_32BIT_LE_VAL;
             LC_CopyBytesWithSwap(&TempBuffer, WPDataPtr, &ConvBuffer, sizeof(uint32));
             ConvBuffer.Unsigned32 = TempBuffer.Unsigned32; /* Straight copy - no extension (signed or unsigned) */
@@ -937,7 +937,7 @@ int32 LC_ValidateWDT(void *TableData)
 {
     LC_WDTEntry_t *TableArray = (LC_WDTEntry_t *)TableData;
 
-    int32 EntryResult = LC_WDTVAL_NO_ERR;
+    int32 EntryResult = LC_WDTVAL_ERR_NONE;
     int32 TableResult = CFE_SUCCESS;
     int32 TableIndex;
 
@@ -960,17 +960,19 @@ int32 LC_ValidateWDT(void *TableData)
         MessageID    = TableArray[TableIndex].MessageID;
         CompareValue = TableArray[TableIndex].ComparisonValue.Unsigned32;
 
-        if (DataType == LC_WATCH_NOT_USED)
+        if (DataType == LC_DATA_WATCH_NOT_USED)
         {
             /*
             ** Unused table entry
             */
             UnusedCount++;
         }
-        else if ((DataType != LC_DATA_BYTE) && (DataType != LC_DATA_UBYTE) && (DataType != LC_DATA_WORD_BE) &&
-                 (DataType != LC_DATA_WORD_LE) && (DataType != LC_DATA_UWORD_BE) && (DataType != LC_DATA_UWORD_LE) &&
-                 (DataType != LC_DATA_DWORD_BE) && (DataType != LC_DATA_DWORD_LE) && (DataType != LC_DATA_UDWORD_BE) &&
-                 (DataType != LC_DATA_UDWORD_LE) && (DataType != LC_DATA_FLOAT_BE) && (DataType != LC_DATA_FLOAT_LE))
+        else if ((DataType != LC_DATA_WATCH_BYTE) && (DataType != LC_DATA_WATCH_UBYTE) &&
+                 (DataType != LC_DATA_WATCH_WORD_BE) && (DataType != LC_DATA_WATCH_WORD_LE) &&
+                 (DataType != LC_DATA_WATCH_UWORD_BE) && (DataType != LC_DATA_WATCH_UWORD_LE) &&
+                 (DataType != LC_DATA_WATCH_DWORD_BE) && (DataType != LC_DATA_WATCH_DWORD_LE) &&
+                 (DataType != LC_DATA_WATCH_UDWORD_BE) && (DataType != LC_DATA_WATCH_UDWORD_LE) &&
+                 (DataType != LC_DATA_WATCH_FLOAT_BE) && (DataType != LC_DATA_WATCH_FLOAT_LE))
         {
             /*
             ** Invalid data type
@@ -996,7 +998,7 @@ int32 LC_ValidateWDT(void *TableData)
             BadCount++;
             EntryResult = LC_WDTVAL_ERR_MID;
         }
-        else if ((DataType == LC_DATA_FLOAT_BE) || (DataType == LC_DATA_FLOAT_LE))
+        else if ((DataType == LC_DATA_WATCH_FLOAT_BE) || (DataType == LC_DATA_WATCH_FLOAT_LE))
         {
             /*
             ** Check the floating point comparison value for
@@ -1031,7 +1033,7 @@ int32 LC_ValidateWDT(void *TableData)
         /*
         ** Generate detailed event for "first" error
         */
-        if ((EntryResult != LC_WDTVAL_NO_ERR) && (TableResult == CFE_SUCCESS))
+        if ((EntryResult != LC_WDTVAL_ERR_NONE) && (TableResult == CFE_SUCCESS))
         {
             if ((EntryResult == LC_WDTVAL_ERR_FPNAN) || (EntryResult == LC_WDTVAL_ERR_FPINF))
             {

--- a/fsw/tables/lc_def_adt.c
+++ b/fsw/tables/lc_def_adt.c
@@ -178,7 +178,7 @@ static CFE_TBL_FileDef_t CFE_TBL_FileDef
 */
 LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
     /* #0 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -192,7 +192,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #1 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -206,7 +206,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #2 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -220,7 +220,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #3 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -234,7 +234,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #4 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -248,7 +248,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #5 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -262,7 +262,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #6 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -276,7 +276,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #7 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -290,7 +290,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #8 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -304,7 +304,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #9 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -318,7 +318,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #10 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -332,7 +332,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #11 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -346,7 +346,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #12 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -360,7 +360,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #13 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -374,7 +374,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #14 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -388,7 +388,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #15 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -402,7 +402,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #16 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -416,7 +416,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #17 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -430,7 +430,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #18 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -444,7 +444,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #19 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -458,7 +458,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #20 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -472,7 +472,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #21 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -486,7 +486,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #22 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -500,7 +500,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #23 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -514,7 +514,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #24 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -528,7 +528,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #25 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -542,7 +542,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #26 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -556,7 +556,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #27 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -570,7 +570,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #28 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -584,7 +584,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #29 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -598,7 +598,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #30 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -612,7 +612,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #31 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -626,7 +626,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #32 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -640,7 +640,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #33 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -654,7 +654,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #34 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -668,7 +668,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #35 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -682,7 +682,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #36 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -696,7 +696,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #37 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -710,7 +710,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #38 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -724,7 +724,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #39 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -738,7 +738,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #40 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -752,7 +752,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #41 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -766,7 +766,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #42 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -780,7 +780,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #43 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -794,7 +794,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #44 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -808,7 +808,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #45 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -822,7 +822,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #46 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -836,7 +836,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #47 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -850,7 +850,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #48 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -864,7 +864,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #49 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -878,7 +878,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #50 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -892,7 +892,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #51 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -906,7 +906,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #52 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -920,7 +920,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #53 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -934,7 +934,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #54 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -948,7 +948,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #55 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -962,7 +962,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #56 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -976,7 +976,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #57 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -990,7 +990,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #58 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1004,7 +1004,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #59 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1018,7 +1018,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #60 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1032,7 +1032,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #61 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1046,7 +1046,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #62 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1060,7 +1060,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #63 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1074,7 +1074,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #64 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1088,7 +1088,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #65 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1102,7 +1102,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #66 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1116,7 +1116,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #67 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1130,7 +1130,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #68 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1144,7 +1144,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #69 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1158,7 +1158,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #70 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1172,7 +1172,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #71 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1186,7 +1186,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #72 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1200,7 +1200,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #73 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1214,7 +1214,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #74 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1228,7 +1228,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #75 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1242,7 +1242,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #76 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1256,7 +1256,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #77 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1270,7 +1270,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #78 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1284,7 +1284,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #79 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1298,7 +1298,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #80 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1312,7 +1312,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #81 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1326,7 +1326,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #82 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1340,7 +1340,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #83 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1354,7 +1354,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #84 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1368,7 +1368,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #85 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1382,7 +1382,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #86 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1396,7 +1396,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #87 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1410,7 +1410,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #88 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1424,7 +1424,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #89 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1438,7 +1438,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #90 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1452,7 +1452,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #91 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1466,7 +1466,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #92 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1480,7 +1480,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #93 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1494,7 +1494,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #94 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1508,7 +1508,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #95 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1522,7 +1522,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #96 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1536,7 +1536,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #97 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1550,7 +1550,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #98 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1564,7 +1564,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #99 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1578,7 +1578,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #100 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1592,7 +1592,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #101 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1606,7 +1606,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #102 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1620,7 +1620,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #103 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1634,7 +1634,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #104 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1648,7 +1648,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #105 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1662,7 +1662,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #106 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1676,7 +1676,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #107 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1690,7 +1690,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #108 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1704,7 +1704,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #109 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1718,7 +1718,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #110 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1732,7 +1732,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #111 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1746,7 +1746,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #112 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1760,7 +1760,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #113 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1774,7 +1774,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #114 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1788,7 +1788,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #115 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1802,7 +1802,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #116 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1816,7 +1816,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #117 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1830,7 +1830,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #118 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1844,7 +1844,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #119 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1858,7 +1858,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #120 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1872,7 +1872,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #121 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1886,7 +1886,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #122 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1900,7 +1900,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #123 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1914,7 +1914,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #124 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1928,7 +1928,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #125 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1942,7 +1942,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #126 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1956,7 +1956,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #127 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1970,7 +1970,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #128 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1984,7 +1984,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #129 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -1998,7 +1998,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #130 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2012,7 +2012,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #131 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2026,7 +2026,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #132 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2040,7 +2040,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #133 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2054,7 +2054,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #134 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2068,7 +2068,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #135 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2082,7 +2082,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #136 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2096,7 +2096,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #137 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2110,7 +2110,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #138 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2124,7 +2124,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #139 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2138,7 +2138,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #140 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2152,7 +2152,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #141 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2166,7 +2166,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #142 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2180,7 +2180,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #143 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2194,7 +2194,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #144 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2208,7 +2208,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #145 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2222,7 +2222,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #146 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2236,7 +2236,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #147 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2250,7 +2250,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #148 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2264,7 +2264,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #149 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2278,7 +2278,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #150 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2292,7 +2292,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #151 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2306,7 +2306,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #152 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2320,7 +2320,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #153 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2334,7 +2334,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #154 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2348,7 +2348,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #155 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2362,7 +2362,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #156 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2376,7 +2376,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #157 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2390,7 +2390,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #158 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2404,7 +2404,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #159 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2418,7 +2418,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #160 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2432,7 +2432,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #161 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2446,7 +2446,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #162 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2460,7 +2460,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #163 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2474,7 +2474,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #164 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2488,7 +2488,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #165 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2502,7 +2502,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #166 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2516,7 +2516,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #167 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2530,7 +2530,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #168 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2544,7 +2544,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #169 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2558,7 +2558,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #170 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2572,7 +2572,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #171 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2586,7 +2586,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #172 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2600,7 +2600,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #173 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2614,7 +2614,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #174 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,
@@ -2628,7 +2628,7 @@ LC_ADTEntry_t LC_DefaultADT[LC_MAX_ACTIONPOINTS] = {
           0, LC_RPN_EQUAL}},
 
     /* #175 (unused) */
-    {.DefaultState      = LC_ACTION_NOT_USED,
+    {.DefaultState      = LC_APSTATE_NOT_USED,
      .MaxPassiveEvents  = 0,
      .MaxPassFailEvents = 0,
      .MaxFailPassEvents = 0,

--- a/fsw/tables/lc_def_wdt.c
+++ b/fsw/tables/lc_def_wdt.c
@@ -46,11 +46,11 @@
 **
 **    ** #112 (Diviner - low s/c bus voltage, level 1) **
 **    {
-**        .DataType                   = LC_DATA_UWORD_BE,
+**        .DataType                   = LC_DATA_WATCH_UWORD_BE,
 **        .OperatorID                 = LC_OPER_LT,
 **        .MessageID                  = PSE_FAST_HK_TLM_MID,
 **        .WatchpointOffset           = 184,
-**        .BitMask                    = LC_NO_BITMASK,
+**        .BitMask                    = LC_BITMASK_NONE,
 **        .CustomFuncArgument         = 0,
 **        .ResultAgeWhenStale         = 0,
 **        .ComparisonValue.Unsigned16in32.Unsigned16 = 3417,
@@ -58,11 +58,11 @@
 **
 **    ** #113 (Diviner - low s/c bus voltage, level 2) **
 **    {
-**        .DataType                   = LC_DATA_UWORD_BE,
+**        .DataType                   = LC_DATA_WATCH_UWORD_BE,
 **        .OperatorID                 = LC_OPER_LT,
 **        .MessageID                  = PSE_FAST_HK_TLM_MID,
 **        .WatchpointOffset           = 184,
-**        .BitMask                    = LC_NO_BITMASK,
+**        .BitMask                    = LC_BITMASK_NONE,
 **        .CustomFuncArgument         = 0,
 **        .ResultAgeWhenStale         = 0,
 **        .ComparisonValue.Unsigned16in32.Unsigned16 = 3319,
@@ -72,7 +72,7 @@
 **
 **    ** #154 (IRU - 24 bit value with custom transform) **
 **    {
-**        .DataType                   = LC_DATA_UDWORD_BE,
+**        .DataType                   = LC_DATA_WATCH_UDWORD_BE,
 **        .OperatorID                 = LC_OPER_CUSTOM,
 **        .MessageID                  = IRU_FAST_HK_TLM_MID,
 **        .WatchpointOffset           = 76,
@@ -100,11 +100,11 @@ static CFE_TBL_FileDef_t CFE_TBL_FileDef
 LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
     /* #0 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -112,11 +112,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #1 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -124,11 +124,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #2 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -136,11 +136,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #3 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -148,11 +148,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #4 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -160,11 +160,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #5 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -172,11 +172,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #6 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -184,11 +184,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #7 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -196,11 +196,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #8 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -208,11 +208,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #9 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -220,11 +220,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #10 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -232,11 +232,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #11 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -244,11 +244,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #12 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -256,11 +256,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #13 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -268,11 +268,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #14 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -280,11 +280,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #15 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -292,11 +292,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #16 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -304,11 +304,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #17 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -316,11 +316,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #18 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -328,11 +328,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #19 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -340,11 +340,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #20 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -352,11 +352,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #21 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -364,11 +364,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #22 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -376,11 +376,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #23 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -388,11 +388,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #24 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -400,11 +400,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #25 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -412,11 +412,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #26 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -424,11 +424,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #27 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -436,11 +436,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #28 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -448,11 +448,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #29 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -460,11 +460,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #30 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -472,11 +472,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #31 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -484,11 +484,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #32 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -496,11 +496,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #33 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -508,11 +508,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #34 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -520,11 +520,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #35 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -532,11 +532,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #36 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -544,11 +544,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #37 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -556,11 +556,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #38 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -568,11 +568,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #39 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -580,11 +580,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #40 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -592,11 +592,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #41 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -604,11 +604,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #42 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -616,11 +616,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #43 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -628,11 +628,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #44 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -640,11 +640,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #45 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -652,11 +652,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #46 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -664,11 +664,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #47 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -676,11 +676,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #48 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -688,11 +688,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #49 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -700,11 +700,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #50 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -712,11 +712,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #51 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -724,11 +724,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #52 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -736,11 +736,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #53 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -748,11 +748,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #54 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -760,11 +760,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #55 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -772,11 +772,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #56 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -784,11 +784,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #57 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -796,11 +796,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #58 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -808,11 +808,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #59 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -820,11 +820,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #60 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -832,11 +832,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #61 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -844,11 +844,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #62 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -856,11 +856,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #63 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -868,11 +868,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #64 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -880,11 +880,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #65 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -892,11 +892,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #66 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -904,11 +904,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #67 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -916,11 +916,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #68 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -928,11 +928,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #69 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -940,11 +940,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #70 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -952,11 +952,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #71 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -964,11 +964,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #72 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -976,11 +976,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #73 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -988,11 +988,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #74 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1000,11 +1000,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #75 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1012,11 +1012,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #76 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1024,11 +1024,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #77 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1036,11 +1036,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #78 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1048,11 +1048,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #79 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1060,11 +1060,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #80 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1072,11 +1072,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #81 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1084,11 +1084,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #82 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1096,11 +1096,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #83 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1108,11 +1108,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #84 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1120,11 +1120,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #85 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1132,11 +1132,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #86 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1144,11 +1144,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #87 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1156,11 +1156,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #88 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1168,11 +1168,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #89 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1180,11 +1180,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #90 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1192,11 +1192,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #91 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1204,11 +1204,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #92 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1216,11 +1216,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #93 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1228,11 +1228,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #94 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1240,11 +1240,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #95 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1252,11 +1252,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #96 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1264,11 +1264,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #97 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1276,11 +1276,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #98 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1288,11 +1288,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #99 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1300,11 +1300,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #100 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1312,11 +1312,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #101 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1324,11 +1324,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #102 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1336,11 +1336,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #103 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1348,11 +1348,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #104 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1360,11 +1360,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #105 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1372,11 +1372,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #106 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1384,11 +1384,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #107 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1396,11 +1396,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #108 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1408,11 +1408,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #109 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1420,11 +1420,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #110 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1432,11 +1432,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #111 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1444,11 +1444,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #112 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1456,11 +1456,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #113 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1468,11 +1468,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #114 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1480,11 +1480,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #115 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1492,11 +1492,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #116 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1504,11 +1504,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #117 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1516,11 +1516,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #118 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1528,11 +1528,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #119 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1540,11 +1540,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #120 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1552,11 +1552,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #121 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1564,11 +1564,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #122 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1576,11 +1576,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #123 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1588,11 +1588,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #124 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1600,11 +1600,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #125 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1612,11 +1612,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #126 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1624,11 +1624,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #127 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1636,11 +1636,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #128 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1648,11 +1648,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #129 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1660,11 +1660,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #130 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1672,11 +1672,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #131 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1684,11 +1684,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #132 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1696,11 +1696,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #133 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1708,11 +1708,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #134 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1720,11 +1720,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #135 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1732,11 +1732,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #136 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1744,11 +1744,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #137 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1756,11 +1756,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #138 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1768,11 +1768,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #139 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1780,11 +1780,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #140 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1792,11 +1792,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #141 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1804,11 +1804,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #142 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1816,11 +1816,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #143 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1828,11 +1828,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #144 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1840,11 +1840,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #145 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1852,11 +1852,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #146 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1864,11 +1864,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #147 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1876,11 +1876,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #148 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1888,11 +1888,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #149 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1900,11 +1900,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #150 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1912,11 +1912,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #151 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1924,11 +1924,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #152 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1936,11 +1936,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #153 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1948,11 +1948,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #154 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1960,11 +1960,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #155 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1972,11 +1972,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #156 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1984,11 +1984,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #157 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -1996,11 +1996,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #158 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2008,11 +2008,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #159 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2020,11 +2020,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #160 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2032,11 +2032,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #161 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2044,11 +2044,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #162 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2056,11 +2056,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #163 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2068,11 +2068,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #164 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2080,11 +2080,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #165 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2092,11 +2092,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #166 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2104,11 +2104,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #167 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2116,11 +2116,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #168 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2128,11 +2128,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #169 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2140,11 +2140,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #170 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2152,11 +2152,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #171 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2164,11 +2164,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #172 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2176,11 +2176,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #173 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2188,11 +2188,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #174 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,
@@ -2200,11 +2200,11 @@ LC_WDTEntry_t LC_DefaultWDT[LC_MAX_WATCHPOINTS] = {
 
     /* #175 (unused) */
     {
-        .DataType                   = LC_WATCH_NOT_USED,
-        .OperatorID                 = LC_NO_OPER,
+        .DataType                   = LC_DATA_WATCH_NOT_USED,
+        .OperatorID                 = LC_OPER_NONE,
         .MessageID                  = CFE_SB_MSGID_RESERVED,
         .WatchpointOffset           = 0,
-        .BitMask                    = LC_NO_BITMASK,
+        .BitMask                    = LC_BITMASK_NONE,
         .CustomFuncArgument         = 0,
         .ResultAgeWhenStale         = 0,
         .ComparisonValue.Unsigned32 = 0,

--- a/unit-test/lc_action_tests.c
+++ b/unit-test/lc_action_tests.c
@@ -71,7 +71,7 @@ void LC_SampleAPs_Test_SingleActionPointError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Sample AP error, invalid current AP state: AP = %%d, State = %%d");
 
-    LC_OperData.ARTPtr[StartIndex].CurrentState = LC_ACTION_NOT_USED;
+    LC_OperData.ARTPtr[StartIndex].CurrentState = LC_APSTATE_NOT_USED;
 
     /* Execute the function being tested */
     LC_SampleAPs(StartIndex, EndIndex);
@@ -1252,7 +1252,7 @@ void LC_ValidateADT_Test_ActionNotUsed(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_ACTIONPOINTS; TableIndex++)
     {
-        LC_OperData.ADTPtr[TableIndex].DefaultState = LC_ACTION_NOT_USED;
+        LC_OperData.ADTPtr[TableIndex].DefaultState = LC_APSTATE_NOT_USED;
     }
 
     /* Execute the function being tested */
@@ -1506,7 +1506,7 @@ void LC_ValidateADT_Test_ValidateRpnAdtValNoError(void)
     Result = LC_ValidateADT(LC_OperData.ADTPtr);
 
     /* Verify results */
-    UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
+    UtAssert_True(Result == LC_ADTVAL_ERR_NONE, "Result == LC_ADTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_ADTVAL_INF_EID);
@@ -1529,7 +1529,7 @@ void LC_ValidateADT_Test_Nominal(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_ACTIONPOINTS; TableIndex++)
     {
-        LC_OperData.ADTPtr[TableIndex].DefaultState      = LC_ACTION_NOT_USED;
+        LC_OperData.ADTPtr[TableIndex].DefaultState      = LC_APSTATE_NOT_USED;
         LC_OperData.ADTPtr[TableIndex].RTSId             = 1;
         LC_OperData.ADTPtr[TableIndex].MaxFailsBeforeRTS = 1;
         LC_OperData.ADTPtr[TableIndex].EventType         = CFE_EVS_EventType_DEBUG;
@@ -1553,7 +1553,7 @@ void LC_ValidateADT_Test_Nominal(void)
     Result = LC_ValidateADT(LC_OperData.ADTPtr);
 
     /* Verify results */
-    UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
+    UtAssert_True(Result == LC_ADTVAL_ERR_NONE, "Result == LC_ADTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_ADTVAL_INF_EID);
@@ -1579,7 +1579,7 @@ void LC_ValidateRPN_Test_RpnAnd(void)
     Result = LC_ValidateRPN(LC_OperData.ADTPtr[0].RPNEquation, &IndexValue, &StackDepthValue);
 
     /* Verify results */
-    UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
+    UtAssert_True(Result == LC_ADTVAL_ERR_NONE, "Result == LC_ADTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
 }
@@ -1599,7 +1599,7 @@ void LC_ValidateRPN_Test_RpnOr(void)
     Result = LC_ValidateRPN(LC_OperData.ADTPtr[0].RPNEquation, &IndexValue, &StackDepthValue);
 
     /* Verify results */
-    UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
+    UtAssert_True(Result == LC_ADTVAL_ERR_NONE, "Result == LC_ADTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
 }
@@ -1619,7 +1619,7 @@ void LC_ValidateRPN_Test_RpnXor(void)
     Result = LC_ValidateRPN(LC_OperData.ADTPtr[0].RPNEquation, &IndexValue, &StackDepthValue);
 
     /* Verify results */
-    UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
+    UtAssert_True(Result == LC_ADTVAL_ERR_NONE, "Result == LC_ADTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
 }
@@ -1638,7 +1638,7 @@ void LC_ValidateRPN_Test_RpnNot(void)
     Result = LC_ValidateRPN(LC_OperData.ADTPtr[0].RPNEquation, &IndexValue, &StackDepthValue);
 
     /* Verify results */
-    UtAssert_True(Result == LC_ADTVAL_NO_ERR, "Result == LC_ADTVAL_NO_ERR");
+    UtAssert_True(Result == LC_ADTVAL_ERR_NONE, "Result == LC_ADTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
 }

--- a/unit-test/lc_cmds_tests.c
+++ b/unit-test/lc_cmds_tests.c
@@ -217,7 +217,7 @@ void LC_AppPipe_Test_SetAPPermoff(void)
     CFE_MSG_FcnCode_t FcnCode;
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_CMD_MID);
-    FcnCode   = LC_SET_AP_PERMOFF_CC;
+    FcnCode   = LC_SET_AP_PERM_OFF_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -824,7 +824,7 @@ void LC_HousekeepingReq_Test_ActionNotUsedStale(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_ACTIONPOINTS; TableIndex++)
     {
-        LC_OperData.ARTPtr[TableIndex].CurrentState = LC_ACTION_NOT_USED;
+        LC_OperData.ARTPtr[TableIndex].CurrentState = LC_APSTATE_NOT_USED;
         LC_OperData.ARTPtr[TableIndex].ActionResult = LC_ACTION_STALE;
     }
 
@@ -1444,7 +1444,7 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOneNotUsed(void)
     {
         LC_OperData.ARTPtr[TableIndex].CurrentState = 99;
     }
-    LC_OperData.ARTPtr[0].CurrentState = LC_ACTION_NOT_USED;
+    LC_OperData.ARTPtr[0].CurrentState = LC_APSTATE_NOT_USED;
 
     /* Execute the function being tested */
     LC_SetAPStateCmd(&UT_CmdBuf.Buf);
@@ -1453,8 +1453,8 @@ void LC_SetAPStateCmd_Test_SetAllActionPointsActiveOneNotUsed(void)
 
     /* Checks for first index: */
     TableIndex = 0;
-    UtAssert_True(LC_OperData.ARTPtr[TableIndex].CurrentState == LC_ACTION_NOT_USED,
-                  "LC_OperData.ARTPtr[TableIndex].CurrentState == LC_ACTION_NOT_USED");
+    UtAssert_True(LC_OperData.ARTPtr[TableIndex].CurrentState == LC_APSTATE_NOT_USED,
+                  "LC_OperData.ARTPtr[TableIndex].CurrentState == LC_APSTATE_NOT_USED");
 
     /* Checks for middle index: */
     TableIndex = LC_MAX_ACTIONPOINTS / 2;
@@ -1689,14 +1689,14 @@ void LC_SetAPStateCmd_Test_UpdateSingleActionPointNotUsed(void)
     UT_CmdBuf.SetAPStateCmd.NewAPState = LC_APSTATE_ACTIVE;
     UT_CmdBuf.SetAPStateCmd.APNumber   = 0;
 
-    LC_OperData.ARTPtr[UT_CmdBuf.SetAPStateCmd.APNumber].CurrentState = LC_ACTION_NOT_USED;
+    LC_OperData.ARTPtr[UT_CmdBuf.SetAPStateCmd.APNumber].CurrentState = LC_APSTATE_NOT_USED;
 
     /* Execute the function being tested */
     LC_SetAPStateCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(LC_OperData.ARTPtr[UT_CmdBuf.SetAPStateCmd.APNumber].CurrentState == LC_ACTION_NOT_USED,
-                  "LC_OperData.ARTPtr[UT_CmdBuf.SetAPStateCmd.APNumber].CurrentState == LC_ACTION_NOT_USED");
+    UtAssert_True(LC_OperData.ARTPtr[UT_CmdBuf.SetAPStateCmd.APNumber].CurrentState == LC_APSTATE_NOT_USED,
+                  "LC_OperData.ARTPtr[UT_CmdBuf.SetAPStateCmd.APNumber].CurrentState == LC_APSTATE_NOT_USED");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);

--- a/unit-test/lc_watch_tests.c
+++ b/unit-test/lc_watch_tests.c
@@ -58,19 +58,19 @@ void LC_CreateHashTable_Test(void)
     /* Default entries to unused */
     for (i = 0; i < LC_MAX_WATCHPOINTS; i++)
     {
-        LC_OperData.WDTPtr[i].DataType = LC_WATCH_NOT_USED;
+        LC_OperData.WDTPtr[i].DataType = LC_DATA_WATCH_NOT_USED;
     }
 
     /* Match MsgID but null watch point list */
-    LC_OperData.WDTPtr[0].DataType  = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[0].DataType  = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[0].MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* MsgID mismatch */
-    LC_OperData.WDTPtr[1].DataType  = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[1].DataType  = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[1].MessageID = LC_UT_MID_1;
 
     /* Match MsgID and non-NULL WatchPLink */
-    LC_OperData.WDTPtr[2].DataType  = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[2].DataType  = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[2].MessageID = LC_UT_MID_1;
 
     /* Execute the function being tested */
@@ -220,7 +220,7 @@ void LC_CheckMsgForWPs_Test_Nominal(void)
     LC_OperData.MessageLinks[1].WatchPtList = &LC_OperData.WatchPtLinks[0];
 
     LC_OperData.WatchPtLinks[0].WatchIndex          = WatchIndex;
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = 0;
     LC_OperData.WDTPtr[WatchIndex].OperatorID       = LC_OPER_CUSTOM;
 
@@ -284,7 +284,7 @@ void LC_CheckMsgForWPs_Test_NominalMsgTime2(void)
     LC_OperData.WatchPtLinks[0].WatchIndex  = WatchIndex;
 
     /* Bad offset */
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = MsgSize + 1;
     LC_OperData.WDTPtr[WatchIndex].OperatorID       = LC_OPER_CUSTOM;
 
@@ -351,7 +351,7 @@ void LC_ProcessWP_Test_CustomFunctionWatchFalse(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType           = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType           = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID         = LC_OPER_CUSTOM;
     LC_OperData.WDTPtr[WatchIndex].CustomFuncArgument = 0;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale = 1;
@@ -387,7 +387,7 @@ void LC_ProcessWP_Test_OperatorCompareError(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType        = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType        = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID      = 99;
     LC_OperData.WRTPtr[WatchIndex].EvaluationCount = 0;
 
@@ -419,7 +419,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -468,7 +468,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousFalse(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_FALSE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -518,7 +518,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_GE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -564,7 +564,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousTrue(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_GE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_TRUE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -635,7 +635,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousTrue(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_TRUE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -681,7 +681,7 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousFalse(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_GE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_FALSE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -715,7 +715,7 @@ void LC_OperatorCompare_Test_DataByte(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_BYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -738,7 +738,7 @@ void LC_OperatorCompare_Test_DataWordLE(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                 = LC_DATA_WORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                 = LC_DATA_WATCH_WORD_LE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID               = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult              = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale       = 1;
@@ -761,7 +761,7 @@ void LC_OperatorCompare_Test_DataDWordLE(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                 = LC_DATA_DWORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                 = LC_DATA_WATCH_DWORD_LE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID               = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult              = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale       = 1;
@@ -784,7 +784,7 @@ void LC_OperatorCompare_Test_DataUByte(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                  = LC_DATA_UBYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                  = LC_DATA_WATCH_UBYTE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID                = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult               = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale        = 1;
@@ -807,7 +807,7 @@ void LC_OperatorCompare_Test_DataUWordLE(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                   = LC_DATA_UWORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                   = LC_DATA_WATCH_UWORD_LE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID                 = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult                = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale         = 1;
@@ -830,7 +830,7 @@ void LC_OperatorCompare_Test_DataUDWordLE(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                   = LC_DATA_UDWORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                   = LC_DATA_WATCH_UDWORD_LE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID                 = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult                = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale         = 1;
@@ -853,7 +853,7 @@ void LC_OperatorCompare_Test_DataFloatLE(void)
     uint16 WatchIndex      = 0;
     uint32 ProcessedWPData = 0;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_FLOAT_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType                = LC_DATA_WATCH_FLOAT_LE;
     LC_OperData.WDTPtr[WatchIndex].OperatorID              = LC_OPER_LE;
     LC_OperData.WRTPtr[WatchIndex].WatchResult             = LC_WATCH_STALE;
     LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale      = 1;
@@ -1426,7 +1426,7 @@ void LC_WPOffsetValid_Test_DataUByte(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_UBYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UBYTE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = 0;
 
     /* Execute the function being tested */
@@ -1451,7 +1451,7 @@ void LC_WPOffsetValid_Test_UWordLE(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_UWORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UWORD_LE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = 0;
 
     /* Execute the function being tested */
@@ -1476,7 +1476,7 @@ void LC_WPOffsetValid_Test_UDWordLE(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_UDWORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UDWORD_LE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = 0;
 
     /* Execute the function being tested */
@@ -1500,7 +1500,7 @@ void LC_WPOffsetValid_Test_FloatLE(void)
 
     UT_SetDefaultReturnValue(UT_KEY(LC_VerifyMsgLength), true);
 
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_FLOAT_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_FLOAT_LE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = 0;
 
     /* Execute the function being tested */
@@ -1566,7 +1566,7 @@ void LC_WPOffsetValid_Test_OffsetError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "WP offset error: MID = 0x%%08lX, WP = %%d, Offset = %%d, DataSize = %%d, MsgLen = %%d");
 
-    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_UBYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType         = LC_DATA_WATCH_UBYTE;
     LC_OperData.WDTPtr[WatchIndex].WatchpointOffset = sizeof(LC_NoArgsCmd_t);
 
     /* Execute the function being tested */
@@ -1601,7 +1601,7 @@ void LC_GetSizedWPData_Test_DataByte(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_BYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_BYTE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1625,7 +1625,7 @@ void LC_GetSizedWPData_Test_DataUByte(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_UBYTE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_UBYTE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1649,7 +1649,7 @@ void LC_GetSizedWPData_Test_DataWordBELittleEndian(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WORD_BE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_WORD_BE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1673,7 +1673,7 @@ void LC_GetSizedWPData_Test_DataWordLELittleEndian(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_WORD_LE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1697,7 +1697,7 @@ void LC_GetSizedWPData_Test_DataUWordBELittleEndian(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_UWORD_BE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_UWORD_BE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1721,7 +1721,7 @@ void LC_GetSizedWPData_Test_DataUWordLELittleEndian(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_UWORD_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_UWORD_LE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1745,7 +1745,7 @@ void LC_GetSizedWPData_Test_DataFloatBELittleEndian(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_FLOAT_BE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_FLOAT_BE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1769,7 +1769,7 @@ void LC_GetSizedWPData_Test_DataFloatLELittleEndian(void)
     WPData[2] = 3;
     WPData[3] = 4;
 
-    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_FLOAT_LE;
+    LC_OperData.WDTPtr[WatchIndex].DataType = LC_DATA_WATCH_FLOAT_LE;
 
     /* Execute the function being tested */
     Result = LC_GetSizedWPData(WatchIndex, WPData, &SizedData);
@@ -1832,7 +1832,7 @@ void LC_ValidateWDT_Test_UnusedTableEntry(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType = LC_WATCH_NOT_USED;
+        LC_OperData.WDTPtr[TableIndex].DataType = LC_DATA_WATCH_NOT_USED;
     }
 
     /* Execute the function being tested */
@@ -1867,22 +1867,22 @@ void LC_ValidateWDT_Test_AllDataTypes(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType = LC_WATCH_NOT_USED;
+        LC_OperData.WDTPtr[TableIndex].DataType = LC_DATA_WATCH_NOT_USED;
     }
 
     /* Add an entry for each data type */
-    LC_OperData.WDTPtr[0].DataType  = LC_DATA_BYTE;
-    LC_OperData.WDTPtr[1].DataType  = LC_DATA_UBYTE;
-    LC_OperData.WDTPtr[2].DataType  = LC_DATA_WORD_BE;
-    LC_OperData.WDTPtr[3].DataType  = LC_DATA_WORD_LE;
-    LC_OperData.WDTPtr[4].DataType  = LC_DATA_UWORD_BE;
-    LC_OperData.WDTPtr[5].DataType  = LC_DATA_UWORD_LE;
-    LC_OperData.WDTPtr[6].DataType  = LC_DATA_DWORD_BE;
-    LC_OperData.WDTPtr[7].DataType  = LC_DATA_DWORD_LE;
-    LC_OperData.WDTPtr[8].DataType  = LC_DATA_UDWORD_BE;
-    LC_OperData.WDTPtr[9].DataType  = LC_DATA_UDWORD_LE;
-    LC_OperData.WDTPtr[10].DataType = LC_DATA_FLOAT_BE;
-    LC_OperData.WDTPtr[11].DataType = LC_DATA_FLOAT_LE;
+    LC_OperData.WDTPtr[0].DataType  = LC_DATA_WATCH_BYTE;
+    LC_OperData.WDTPtr[1].DataType  = LC_DATA_WATCH_UBYTE;
+    LC_OperData.WDTPtr[2].DataType  = LC_DATA_WATCH_WORD_BE;
+    LC_OperData.WDTPtr[3].DataType  = LC_DATA_WATCH_WORD_LE;
+    LC_OperData.WDTPtr[4].DataType  = LC_DATA_WATCH_UWORD_BE;
+    LC_OperData.WDTPtr[5].DataType  = LC_DATA_WATCH_UWORD_LE;
+    LC_OperData.WDTPtr[6].DataType  = LC_DATA_WATCH_DWORD_BE;
+    LC_OperData.WDTPtr[7].DataType  = LC_DATA_WATCH_DWORD_LE;
+    LC_OperData.WDTPtr[8].DataType  = LC_DATA_WATCH_UDWORD_BE;
+    LC_OperData.WDTPtr[9].DataType  = LC_DATA_WATCH_UDWORD_LE;
+    LC_OperData.WDTPtr[10].DataType = LC_DATA_WATCH_FLOAT_BE;
+    LC_OperData.WDTPtr[11].DataType = LC_DATA_WATCH_FLOAT_LE;
 
     /* Execute the function being tested */
     Result = LC_ValidateWDT(LC_OperData.WDTPtr);
@@ -1924,7 +1924,7 @@ void LC_ValidateWDT_Test_AllOperatorIDs(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType  = LC_DATA_BYTE;
+        LC_OperData.WDTPtr[TableIndex].DataType  = LC_DATA_WATCH_BYTE;
         LC_OperData.WDTPtr[TableIndex].MessageID = LC_UT_MID_1;
     }
 
@@ -2015,7 +2015,7 @@ void LC_ValidateWDT_Test_InvalidOperator(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_BYTE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_BYTE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = 99;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = LC_UT_MID_2;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 3;
@@ -2057,7 +2057,7 @@ void LC_ValidateWDT_Test_BadMessageID(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_BYTE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_BYTE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = LC_OPER_LT;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = CFE_SB_INVALID_MSG_ID;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 3;
@@ -2099,7 +2099,7 @@ void LC_ValidateWDT_Test_NaN(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_FLOAT_LE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_FLOAT_LE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = LC_OPER_LT;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = LC_UT_MID_1;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 0x7F8FFFFF;
@@ -2140,7 +2140,7 @@ void LC_ValidateWDT_Test_Inf(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_FLOAT_LE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_FLOAT_LE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = LC_OPER_LT;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = LC_UT_MID_1;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 0x7F800000;
@@ -2180,7 +2180,7 @@ void LC_ValidateWDT_Test_FloatingPointPassed(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_FLOAT_LE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_FLOAT_LE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = LC_OPER_LT;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = LC_UT_MID_1;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 1;
@@ -2190,7 +2190,7 @@ void LC_ValidateWDT_Test_FloatingPointPassed(void)
     Result = LC_ValidateWDT(LC_OperData.WDTPtr);
 
     /* Verify results */
-    UtAssert_True(Result == LC_WDTVAL_NO_ERR, "Result == LC_WDTVAL_NO_ERR");
+    UtAssert_True(Result == LC_WDTVAL_ERR_NONE, "Result == LC_WDTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_WDTVAL_INF_EID);
@@ -2213,7 +2213,7 @@ void LC_ValidateWDT_Test_NonFloatingPointPassed(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_BYTE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_BYTE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = LC_OPER_LT;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = LC_UT_MID_1;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 1;
@@ -2223,7 +2223,7 @@ void LC_ValidateWDT_Test_NonFloatingPointPassed(void)
     Result = LC_ValidateWDT(LC_OperData.WDTPtr);
 
     /* Verify results */
-    UtAssert_True(Result == LC_WDTVAL_NO_ERR, "Result == LC_WDTVAL_NO_ERR");
+    UtAssert_True(Result == LC_WDTVAL_ERR_NONE, "Result == LC_WDTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_WDTVAL_INF_EID);
@@ -2246,7 +2246,7 @@ void LC_ValidateWDT_Test_FloatBE(void)
 
     for (TableIndex = 0; TableIndex < LC_MAX_WATCHPOINTS; TableIndex++)
     {
-        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_FLOAT_BE;
+        LC_OperData.WDTPtr[TableIndex].DataType                   = LC_DATA_WATCH_FLOAT_BE;
         LC_OperData.WDTPtr[TableIndex].OperatorID                 = LC_OPER_LT;
         LC_OperData.WDTPtr[TableIndex].MessageID                  = LC_UT_MID_1;
         LC_OperData.WDTPtr[TableIndex].ComparisonValue.Unsigned32 = 1;
@@ -2256,7 +2256,7 @@ void LC_ValidateWDT_Test_FloatBE(void)
     Result = LC_ValidateWDT(LC_OperData.WDTPtr);
 
     /* Verify results */
-    UtAssert_True(Result == LC_WDTVAL_NO_ERR, "Result == LC_WDTVAL_NO_ERR");
+    UtAssert_True(Result == LC_WDTVAL_ERR_NONE, "Result == LC_WDTVAL_ERR_NONE");
 
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_WDTVAL_INF_EID);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This is a simple search and replace of nonconformant symbol names.

Mapping from the old symbol name to the new symbol name is put behind a deprecated compatibility switch

Fixes #70

**Testing performed**
Build and run all unit tests

**Expected behavior changes**
None - just a simple symbol rename

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
