### PR TITLE
Fix #77, Add break to default case of switch in LC_VerifyMsgLength

### DIFF
--- a/docs/dox_src/cfs_lc.dox
+++ b/docs/dox_src/cfs_lc.dox
@@ -516,7 +516,7 @@
   </I>
 
   <B> (Q)
-     When would a actionpoint evalute to #LC_ACTION_STALE?
+     When would an actionpoint evalute to #LC_ACTION_STALE?
   </B> <BR> <BR> <I>
      #LC_ACTION_STALE is an initialization value for the Actionpoint
      Results Table. If an actionpoint has this ActionResult then one of
@@ -534,7 +534,7 @@
   </I>
 
   <B> (Q)
-     When would a actionpoint evalute to #LC_ACTION_ERROR?
+     When would an actionpoint evalute to #LC_ACTION_ERROR?
   </B> <BR> <BR> <I>
      #LC_ACTION_ERROR is a runtime error indicator for actionpoint processing.
      Such a result should be rare since most of the causes are invalid actionpoint

--- a/fsw/inc/lc_events.h
+++ b/fsw/inc/lc_events.h
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *   Specification for the CFS Limit Checker (LC) event identifers.
+ *   Specification for the CFS Limit Checker (LC) event identifiers.
  */
 #ifndef LC_EVENTS_H
 #define LC_EVENTS_H
@@ -179,7 +179,7 @@
  *  \par Cause:
  *
  *  This event message is issued when the CDS area for the
- *  watchpoint restuls table (WRT) data could not be registered.
+ *  watchpoint results table (WRT) data could not be registered.
  */
 #define LC_WRT_CDS_REGISTER_ERR_EID 12
 
@@ -191,7 +191,7 @@
  *  \par Cause:
  *
  *  This event message is issued when the CDS area for the
- *  actionpont restuls table (ART) data could not be registered.
+ *  actionpont results table (ART) data could not be registered.
  */
 #define LC_ART_CDS_REGISTER_ERR_EID 13
 
@@ -208,7 +208,7 @@
 #define LC_APP_CDS_REGISTER_ERR_EID 14
 
 /**
- * \brief LC Watchpoint Defintion Table Load From File Failed Event ID
+ * \brief LC Watchpoint Definition Table Load From File Failed Event ID
  *
  *  \par Type: ERROR
  *
@@ -539,7 +539,7 @@
 #define LC_APSTATS_INF_EID 38
 
 /**
- * \brief LC Reset Watchpoint Stats Watchpoint Number Invalid Evnt ID
+ * \brief LC Reset Watchpoint Stats Watchpoint Number Invalid Event ID
  *
  *  \par Type: ERROR
  *
@@ -581,7 +581,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when a actionpoint sample request is received
+ *  This event message is issued when an actionpoint sample request is received
  *  with a message length that doesn't match the expected value.
  */
 #define LC_APSAMPLE_LEN_ERR_EID 42
@@ -686,7 +686,7 @@
 #define LC_WP_DATATYPE_ERR_EID 50
 
 /**
- * \brief LC Watchpoint Operatior ID Invalid Event ID
+ * \brief LC Watchpoint Operator ID Invalid Event ID
  *
  *  \par Type: ERROR
  *
@@ -724,7 +724,7 @@
 #define LC_WP_OFFSET_ERR_EID 53
 
 /**
- * \brief LC Watchpoint Defintion Table Validation Floating Point Check Failed Event ID
+ * \brief LC Watchpoint Definition Table Validation Floating Point Check Failed Event ID
  *
  *  \par Type: ERROR
  *
@@ -752,7 +752,7 @@
 #define LC_WDTVAL_ERR_EID 55
 
 /**
- * \brief LC Watchpoint Defintion Table Validation Results Event ID
+ * \brief LC Watchpoint Definition Table Validation Results Event ID
  *
  *  \par Type: INFORMATION
  *
@@ -856,7 +856,7 @@
  *  \par Cause:
  *
  *  This event message is issued on the first error when a table validation
- *  fails for a actionpoint definition table (ADT) load and the error is
+ *  fails for an actionpoint definition table (ADT) load and the error is
  *  a failed RPN equation check.
  */
 #define LC_ADTVAL_RPNERR_EID 64
@@ -875,7 +875,7 @@
 #define LC_ADTVAL_ERR_EID 65
 
 /**
- * \brief LC Actionpoint Defintion Table Validation Result Event ID
+ * \brief LC Actionpoint Definition Table Validation Result Event ID
  *
  *  \par Type: INFORMATION
  *

--- a/fsw/inc/lc_platform_cfg.h
+++ b/fsw/inc/lc_platform_cfg.h
@@ -232,7 +232,7 @@
  *
  *  \par Description:
  *       The maximum RTS ID that LC will allow during table
- *       validation in a Actionpoint Definition Table (ADT) entry
+ *       validation in an Actionpoint Definition Table (ADT) entry
  *
  *  \par Limits:
  *       This parameter can't be larger than an unsigned 16 bit

--- a/fsw/src/lc_app.c
+++ b/fsw/src/lc_app.c
@@ -335,12 +335,12 @@ int32 LC_TableInit(void)
 ** LC task use of Critical Data Store (CDS)
 **
 **    Global application data (LC_AppData)
-**    Watchpint results dump only table data
+**    Watchpoint results dump only table data
 **    Actionpoint results dump only table data
 **
 ** cFE Table Services use of CDS for LC task
 **
-**    Watchpint definition loadable table data
+**    Watchpoint definition loadable table data
 **    Actionpoint definition loadable table data
 **
 ** LC table initialization logic re CDS

--- a/fsw/src/lc_dispatch.c
+++ b/fsw/src/lc_dispatch.c
@@ -87,6 +87,7 @@ bool LC_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
                                   (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
                                   (int)ExpectedLength);
                 LC_AppData.CmdErrCount++;
+                break;
         }
 
         result = false;

--- a/fsw/src/lc_watch.h
+++ b/fsw/src/lc_watch.h
@@ -232,7 +232,7 @@ uint8 LC_UnsignedCompare(uint16 WatchIndex, uint32 WPValue, uint32 CompareValue)
  *
  *  \par Description
  *       Support function for watchpoint processing that will perform
- *       an floating point watchpoint data comparison based upon the operator
+ *       a floating point watchpoint data comparison based upon the operator
  *       specified in the watchpoint definition table
  *
  *  \par Assumptions, External Events, and Notes:


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #77 
  - Adds a `break` statement to the `default` case of the `switch` block.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Purely a style/guidelines issue for consistency and future maintenance.
No change to logic (the `default` case would fall through to the bottom and exit the switch block even without a `break` statement).
Guidelines and cFS consistency dictate that all switch cases (including `default`) should be terminated by an unconditional `break` statement.

**Contributor Info**
Avi Weiss @thnkslprpt