### PR TITLE
Fix #79, Combine consecutive, mutually-exclusive status checks

### DIFF
--- a/fsw/src/lc_app.c
+++ b/fsw/src/lc_app.c
@@ -515,8 +515,7 @@ int32 LC_CreateResultTables(void)
         CFE_EVS_SendEvent(LC_WRT_REGISTER_ERR_EID, CFE_EVS_EventType_ERROR, "Error registering WRT, RC=0x%08X",
                           (unsigned int)Result);
     }
-
-    if (Result == CFE_SUCCESS)
+    else
     {
         Result = CFE_TBL_GetAddress((void *)&LC_OperData.WRTPtr, LC_OperData.WRTHandle);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #79 
  - Consecutive, mutually-exclusive status checks combined into an `if`/`else`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to logic.
Single evaluation instead of twice in this if block now.

**Contributor Info**
Avi Weiss @thnkslprpt