### PR TITLE
Fix #83, use generated stubs

### DIFF
--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_cfe_coverage_stubs("lc_internal"
   stubs/lc_custom_stubs.c
   stubs/lc_utils_stubs.c
   stubs/lc_watch_stubs.c
+  stubs/lc_global_stubs.c
 )
 
 # Link with the cfe core stubs and unit test assert libs
@@ -29,14 +30,14 @@ target_include_directories(coverage-lc_internal-stubs PUBLIC ../fsw/src)
 # Accomplish this by cycling through all the app's source files, there must be
 # a *_tests file for each
 foreach(SRCFILE ${APP_SRC_FILES})
-    
-    # Get the base sourcefile name as a module name without path or the  
+
+    # Get the base sourcefile name as a module name without path or the
     # extension, this will be used as the base name of the unit test file.
     get_filename_component(UNIT_NAME "${SRCFILE}" NAME_WE)
 
     # Use the module name to make the test name by adding _tests to the end
     set(TESTS_NAME "${UNIT_NAME}_tests")
-    
+
     # Make the test sourcefile name with unit test path and extension
     set(TESTS_SOURCE_FILE "${PROJECT_SOURCE_DIR}/unit-test/${TESTS_NAME}.c")
 

--- a/unit-test/stubs/lc_action_stubs.c
+++ b/unit-test/stubs/lc_action_stubs.c
@@ -19,33 +19,11 @@
 
 /**
  * @file
- *   Specification for the CFS Limit Checker (LC) routines that
- *   handle actionpoint processing
- */
-
-/**
- * @file
  *
  * Auto-Generated stub implementations for functions defined in lc_action header
  */
 
 #include "lc_action.h"
-#include "lc_app.h"
-#include "lc_msg.h"
-#include "lc_msgdefs.h"
-#include "lc_msgids.h"
-#include "lc_events.h"
-#include "lc_version.h"
-#include "lc_test_utils.h"
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <unistd.h>
-#include <stdlib.h>
-
 #include "utgenstub.h"
 
 /*

--- a/unit-test/stubs/lc_app_stubs.c
+++ b/unit-test/stubs/lc_app_stubs.c
@@ -19,39 +19,12 @@
 
 /**
  * @file
- *   Unit specification for the Core Flight System (CFS)
- *   Limit Checker (LC) Application.
- */
-
-/**
- * @file
  *
  * Auto-Generated stub implementations for functions defined in lc_app header
  */
 
 #include "lc_app.h"
-#include "lc_msg.h"
-#include "lc_msgdefs.h"
-#include "lc_msgids.h"
-#include "lc_events.h"
-#include "lc_version.h"
-#include "lc_test_utils.h"
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <unistd.h>
-#include <stdlib.h>
-
 #include "utgenstub.h"
-
-/************************************************************************
-** LC Global Data
-*************************************************************************/
-LC_OperData_t LC_OperData;
-LC_AppData_t  LC_AppData;
 
 /*
  * ----------------------------------------------------
@@ -74,6 +47,7 @@ int32 LC_AppInit(void)
  */
 void LC_AppMain(void)
 {
+
     UT_GenStub_Execute(LC_AppMain, Basic, NULL);
 }
 

--- a/unit-test/stubs/lc_cmds_stubs.c
+++ b/unit-test/stubs/lc_cmds_stubs.c
@@ -19,33 +19,11 @@
 
 /**
  * @file
- *   Specification for the CFS Limit Checker (LC) routines that
- *   handle command processing
- */
-
-/**
- * @file
  *
  * Auto-Generated stub implementations for functions defined in lc_cmds header
  */
 
 #include "lc_cmds.h"
-#include "lc_app.h"
-#include "lc_msg.h"
-#include "lc_msgdefs.h"
-#include "lc_msgids.h"
-#include "lc_events.h"
-#include "lc_version.h"
-#include "lc_test_utils.h"
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <unistd.h>
-#include <stdlib.h>
-
 #include "utgenstub.h"
 
 /*
@@ -123,6 +101,7 @@ void LC_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
  */
 void LC_ResetCounters(void)
 {
+
     UT_GenStub_Execute(LC_ResetCounters, Basic, NULL);
 }
 
@@ -131,11 +110,11 @@ void LC_ResetCounters(void)
  * Generated stub function for LC_ResetResultsAP()
  * ----------------------------------------------------
  */
-void LC_ResetResultsAP(uint32 StartIndex, uint32 EndIndex, bool ResetCmd)
+void LC_ResetResultsAP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd)
 {
     UT_GenStub_AddParam(LC_ResetResultsAP, uint32, StartIndex);
     UT_GenStub_AddParam(LC_ResetResultsAP, uint32, EndIndex);
-    UT_GenStub_AddParam(LC_ResetResultsAP, bool, ResetCmd);
+    UT_GenStub_AddParam(LC_ResetResultsAP, bool, ResetStatsCmd);
 
     UT_GenStub_Execute(LC_ResetResultsAP, Basic, NULL);
 }
@@ -145,11 +124,11 @@ void LC_ResetResultsAP(uint32 StartIndex, uint32 EndIndex, bool ResetCmd)
  * Generated stub function for LC_ResetResultsWP()
  * ----------------------------------------------------
  */
-void LC_ResetResultsWP(uint32 StartIndex, uint32 EndIndex, bool ResetCmd)
+void LC_ResetResultsWP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd)
 {
     UT_GenStub_AddParam(LC_ResetResultsWP, uint32, StartIndex);
     UT_GenStub_AddParam(LC_ResetResultsWP, uint32, EndIndex);
-    UT_GenStub_AddParam(LC_ResetResultsWP, bool, ResetCmd);
+    UT_GenStub_AddParam(LC_ResetResultsWP, bool, ResetStatsCmd);
 
     UT_GenStub_Execute(LC_ResetResultsWP, Basic, NULL);
 }

--- a/unit-test/stubs/lc_custom_stubs.c
+++ b/unit-test/stubs/lc_custom_stubs.c
@@ -19,33 +19,11 @@
 
 /**
  * @file
- *   Specification for the CFS Limit Checker (LC) mission specific
- *   custom function template
- */
-
-/**
- * @file
  *
  * Auto-Generated stub implementations for functions defined in lc_custom header
  */
 
 #include "lc_custom.h"
-#include "lc_app.h"
-#include "lc_msg.h"
-#include "lc_msgdefs.h"
-#include "lc_msgids.h"
-#include "lc_events.h"
-#include "lc_version.h"
-#include "lc_test_utils.h"
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <unistd.h>
-#include <stdlib.h>
-
 #include "utgenstub.h"
 
 /*
@@ -56,17 +34,16 @@
 uint8 LC_CustomFunction(uint16 WatchIndex, uint32 ProcessedWPData, const CFE_SB_Buffer_t *BufPtr,
                         uint32 WDTCustomFuncArg)
 {
-    /*UT_GenStub_SetupReturnBuffer(LC_CustomFunction, uint8);
+    UT_GenStub_SetupReturnBuffer(LC_CustomFunction, uint8);
 
-    UT_GenStub_AddParam(LC_CustomFunction, uint16 , WatchIndex);
-    UT_GenStub_AddParam(LC_CustomFunction, uint32 , ProcessedWPData);
-    UT_GenStub_AddParam(LC_CustomFunction, const CFE_SB_Buffer_t* , BufPtr);
-    UT_GenStub_AddParam(LC_CustomFunction, uint32 , WDTCustomFuncArg);
+    UT_GenStub_AddParam(LC_CustomFunction, uint16, WatchIndex);
+    UT_GenStub_AddParam(LC_CustomFunction, uint32, ProcessedWPData);
+    UT_GenStub_AddParam(LC_CustomFunction, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(LC_CustomFunction, uint32, WDTCustomFuncArg);
 
     UT_GenStub_Execute(LC_CustomFunction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_CustomFunction, uint8);*/
-    return UT_DEFAULT_IMPL(LC_CustomFunction);
+    return UT_GenStub_GetReturnValue(LC_CustomFunction, uint8);
 }
 
 /*

--- a/unit-test/stubs/lc_global_stubs.c
+++ b/unit-test/stubs/lc_global_stubs.c
@@ -1,0 +1,37 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,921-1, and identified as “CFS Limit Checker
+ * Application version 2.2.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in lc_app header
+ */
+
+#include "lc_app.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+/************************************************************************
+** LC Global Data
+*************************************************************************/
+LC_OperData_t LC_OperData;
+LC_AppData_t  LC_AppData;

--- a/unit-test/stubs/lc_utils_stubs.c
+++ b/unit-test/stubs/lc_utils_stubs.c
@@ -19,32 +19,11 @@
 
 /**
  * @file
- *   CFS Limit Checker (LC) utility functions
- */
-
-/**
- * @file
  *
  * Auto-Generated stub implementations for functions defined in lc_utils header
  */
 
 #include "lc_utils.h"
-#include "lc_app.h"
-#include "lc_msg.h"
-#include "lc_msgdefs.h"
-#include "lc_msgids.h"
-#include "lc_events.h"
-#include "lc_version.h"
-#include "lc_test_utils.h"
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <unistd.h>
-#include <stdlib.h>
-
 #include "utgenstub.h"
 
 /*
@@ -96,13 +75,12 @@ int32 LC_UpdateTaskCDS(void)
  */
 bool LC_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 {
-    /* UT_GenStub_SetupReturnBuffer(LC_VerifyMsgLength, bool); */
+    UT_GenStub_SetupReturnBuffer(LC_VerifyMsgLength, bool);
 
-    /* UT_GenStub_AddParam(LC_VerifyMsgLength, const CFE_MSG_Message_t* , MsgPtr); */
-    /* UT_GenStub_AddParam(LC_VerifyMsgLength, size_t , ExpectedLength); */
+    UT_GenStub_AddParam(LC_VerifyMsgLength, const CFE_MSG_Message_t *, MsgPtr);
+    UT_GenStub_AddParam(LC_VerifyMsgLength, size_t, ExpectedLength);
 
-    /* UT_GenStub_Execute(LC_VerifyMsgLength, Basic, NULL); */
+    UT_GenStub_Execute(LC_VerifyMsgLength, Basic, NULL);
 
-    /* return UT_GenStub_GetReturnValue(LC_VerifyMsgLength, bool); */
-    return UT_DEFAULT_IMPL(LC_VerifyMsgLength) != 0;
+    return UT_GenStub_GetReturnValue(LC_VerifyMsgLength, bool);
 }

--- a/unit-test/stubs/lc_watch_stubs.c
+++ b/unit-test/stubs/lc_watch_stubs.c
@@ -19,33 +19,11 @@
 
 /**
  * @file
- *   Specification for the CFS Limit Checker (LC) routines that
- *   handle watchpoint processing
- */
-
-/**
- * @file
  *
  * Auto-Generated stub implementations for functions defined in lc_watch header
  */
 
 #include "lc_watch.h"
-#include "lc_app.h"
-#include "lc_msg.h"
-#include "lc_msgdefs.h"
-#include "lc_msgids.h"
-#include "lc_events.h"
-#include "lc_version.h"
-#include "lc_test_utils.h"
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <unistd.h>
-#include <stdlib.h>
-
 #include "utgenstub.h"
 
 /*
@@ -84,6 +62,7 @@ void LC_CheckMsgForWPs(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
  */
 void LC_CreateHashTable(void)
 {
+
     UT_GenStub_Execute(LC_CreateHashTable, Basic, NULL);
 }
 
@@ -97,8 +76,8 @@ uint8 LC_FloatCompare(uint16 WatchIndex, LC_MultiType_t *WPMultiType, LC_MultiTy
     UT_GenStub_SetupReturnBuffer(LC_FloatCompare, uint8);
 
     UT_GenStub_AddParam(LC_FloatCompare, uint16, WatchIndex);
-    UT_GenStub_AddParam(LC_FloatCompare, LC_MultiType_t, WPMultiType);
-    UT_GenStub_AddParam(LC_FloatCompare, LC_MultiType_t, CompareMultiType);
+    UT_GenStub_AddParam(LC_FloatCompare, LC_MultiType_t *, WPMultiType);
+    UT_GenStub_AddParam(LC_FloatCompare, LC_MultiType_t *, CompareMultiType);
 
     UT_GenStub_Execute(LC_FloatCompare, Basic, NULL);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Separate the global variables into separate stub source units, then re-run the stub generator for all internal APIs. The committed result here is the exact output of the tool, unmodified.

Fixes #83

**Testing performed**
Build and run LC with all tests

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.