### PR TITLE
Fix #90, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,14 +3,14 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:
     name: Codeql Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
     with:
-      component-path: apps/lc 
+      component-path: apps/lc
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/lc'
       setup: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/docs/dox_src/cfs_lc.dox
+++ b/docs/dox_src/cfs_lc.dox
@@ -54,7 +54,7 @@
 
   This document provides a complete specification for the commands and telemetry associated
   with the CFS Limit Checker (LC) application software.  The document is intended primarily
-  for users of the software (operations personal, test engineers, and maintenance personnel).
+  for users of the software (operations personnel, test engineers, and maintenance personnel).
   The last section of the document, the deployment guide section, is intended for mission
   developers when deploying and configuring the LC application software for a mission
   flight software build environment.
@@ -113,7 +113,7 @@
   is encountered, an event message is issued and a Relative Time Sequence (RTS) command
   script may be initiated to respond to the threshold violation.
 
-  LC is a table driven application. Monitoring and response configuration data is stored in
+  LC is a table-driven application. Monitoring and response configuration data is stored in
   definition tables that can be updated by the ground operators, while statistics on threshold
   violations are stored in dump-only results tables and summarized in housekeeping data.
 
@@ -195,7 +195,7 @@
   \image html LC_Monitor_Process.png "LC Monitoring Process Example Diagram"
   \image latex LC_Monitor_Process.png "LC Monitoring Process Example Diagram"
 
-  Since LC is a table driven application, it's behavior is dictated by the contents of the
+  Since LC is a table-driven application, it's behavior is dictated by the contents of the
   WDT and ADT configuration tables. To change this behavior is simply a matter of loading a
   new table with modified parameters. LC will check for any pending table updates whenever
   it processes a housekeeping request. If the table passes validation it will go into
@@ -295,11 +295,11 @@
   #LC_MAX_ACTIONPOINTS. The index into this table is the same Actionpoint ID used for the
   corresponding definition table entry.
 
-  The entire WDT is searched anytime a message is received that may contain watchpoints.
+  The entire WDT is searched any time a message is received that may contain watchpoints.
   For this reason, it is important that unused entries are properly marked by setting
   the WDT parameter DataType to #LC_DATA_WATCH_NOT_USED.
 
-  The entire ADT is processed anytime a sample request is received that specifies an
+  The entire ADT is processed any time a sample request is received that specifies an
   actionpoint equal to #LC_ALL_ACTIONPOINTS. For this reason, it is important that unused
   entries are properly marked by setting the ADT parameter DefaultState to
   #LC_APSTATE_NOT_USED.

--- a/fsw/src/lc_app.c
+++ b/fsw/src/lc_app.c
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *   The CFS Limit Checker (LC) is a table driven application
+ *   The CFS Limit Checker (LC) is a table-driven application
  *   that provides telemetry monitoring and autonomous response
  *   capabilities to Core Flight Executive (cFE) based systems.
  */
@@ -179,9 +179,9 @@ void LC_AppMain(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_AppInit(void)
+CFE_Status_t LC_AppInit(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /*
     ** Zero out the global data structures...
@@ -229,9 +229,9 @@ int32 LC_AppInit(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_EvsInit(void)
+CFE_Status_t LC_EvsInit(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /*
     ** If an application event filter table is added
@@ -257,9 +257,9 @@ int32 LC_EvsInit(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_SbInit(void)
+CFE_Status_t LC_SbInit(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /*
     ** Initialize housekeeping packet...
@@ -327,9 +327,9 @@ int32 LC_SbInit(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_TableInit(void)
+CFE_Status_t LC_TableInit(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
 /*
 ** LC task use of Critical Data Store (CDS)
@@ -500,11 +500,11 @@ int32 LC_TableInit(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_CreateResultTables(void)
+CFE_Status_t LC_CreateResultTables(void)
 {
-    int32  Result;
-    uint32 DataSize;
-    uint32 OptionFlags;
+    CFE_Status_t Result;
+    uint32       DataSize;
+    uint32       OptionFlags;
 
     /*
     ** Set "dump only" table option flags
@@ -575,11 +575,11 @@ int32 LC_CreateResultTables(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_CreateDefinitionTables(void)
+CFE_Status_t LC_CreateDefinitionTables(void)
 {
-    int32  Result;
-    uint32 DataSize;
-    uint32 OptionFlags = CFE_TBL_OPT_DEFAULT;
+    CFE_Status_t Result;
+    uint32       DataSize;
+    uint32       OptionFlags = CFE_TBL_OPT_DEFAULT;
 
     /*
     ** If CDS is still enabled, try to register the 2 definition tables as critical
@@ -731,10 +731,10 @@ int32 LC_CreateDefinitionTables(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_CreateTaskCDS(void)
+CFE_Status_t LC_CreateTaskCDS(void)
 {
-    int32  Result;
-    uint32 DataSize;
+    CFE_Status_t Result;
+    uint32       DataSize;
 
     /*
     ** Create CDS and try to restore Watchpoint Results Table (WRT) data
@@ -858,9 +858,9 @@ int32 LC_CreateTaskCDS(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_LoadDefaultTables(void)
+CFE_Status_t LC_LoadDefaultTables(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /*
     ** Load default watchpoint definition table (WDT)

--- a/fsw/src/lc_app.h
+++ b/fsw/src/lc_app.h
@@ -237,7 +237,7 @@ void LC_AppMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 LC_AppInit(void);
+CFE_Status_t LC_AppInit(void);
 
 /**
  * \brief Initialize Event Services
@@ -252,7 +252,7 @@ int32 LC_AppInit(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 LC_EvsInit(void);
+CFE_Status_t LC_EvsInit(void);
 
 /**
  * \brief Initialize Software Bus
@@ -267,7 +267,7 @@ int32 LC_EvsInit(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 LC_SbInit(void);
+CFE_Status_t LC_SbInit(void);
 
 /**
  * \brief Initialize Table Services (includes CDS)
@@ -286,7 +286,7 @@ int32 LC_SbInit(void);
  *
  *  \sa LC_SAVE_TO_CDS
  */
-int32 LC_TableInit(void);
+CFE_Status_t LC_TableInit(void);
 
 /**
  * \brief Create Watchpoint and Actionpoint Result Tables
@@ -303,7 +303,7 @@ int32 LC_TableInit(void);
  *
  *  \sa #LC_TableInit
  */
-int32 LC_CreateResultTables(void);
+CFE_Status_t LC_CreateResultTables(void);
 
 /**
  * \brief Create Watchpoint and Actionpoint Definition Tables
@@ -320,7 +320,7 @@ int32 LC_CreateResultTables(void);
  *
  *  \sa #LC_TableInit
  */
-int32 LC_CreateDefinitionTables(void);
+CFE_Status_t LC_CreateDefinitionTables(void);
 
 /**
  * \brief Create Result Table and Application Data CDS Areas
@@ -337,7 +337,7 @@ int32 LC_CreateDefinitionTables(void);
  *
  *  \sa #LC_TableInit
  */
-int32 LC_CreateTaskCDS(void);
+CFE_Status_t LC_CreateTaskCDS(void);
 
 /**
  * \brief Load Default Table Values
@@ -356,6 +356,6 @@ int32 LC_CreateTaskCDS(void);
  *
  *  \sa #LC_TableInit
  */
-int32 LC_LoadDefaultTables(void);
+CFE_Status_t LC_LoadDefaultTables(void);
 
 #endif

--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -110,7 +110,7 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr)
 /* Housekeeping request                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 LC_SendHkCmd(const CFE_MSG_CommandHeader_t *MsgPtr)
+CFE_Status_t LC_SendHkCmd(const CFE_MSG_CommandHeader_t *MsgPtr)
 {
     uint16 TableIndex;
     uint16 HKIndex;

--- a/fsw/src/lc_cmds.h
+++ b/fsw/src/lc_cmds.h
@@ -106,7 +106,7 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr);
  *  \param[in] MsgPtr Pointer to command header
  *
  */
-int32 LC_SendHkCmd(const CFE_MSG_CommandHeader_t *MsgPtr);
+CFE_Status_t LC_SendHkCmd(const CFE_MSG_CommandHeader_t *MsgPtr);
 
 /**
  * \brief Noop command

--- a/fsw/src/lc_dispatch.c
+++ b/fsw/src/lc_dispatch.c
@@ -242,9 +242,8 @@ void LC_ResetWPStatsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /* Process a command pipe message                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32             Status      = CFE_SUCCESS;
     CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t CommandCode = 0;
 
@@ -324,5 +323,5 @@ int32 LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 
     } /* end MessageID switch */
 
-    return Status;
+    return CFE_SUCCESS;
 }

--- a/fsw/src/lc_dispatch.h
+++ b/fsw/src/lc_dispatch.h
@@ -53,6 +53,6 @@
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 LC_AppPipe(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t LC_AppPipe(const CFE_SB_Buffer_t *BufPtr);
 
 #endif

--- a/fsw/src/lc_utils.c
+++ b/fsw/src/lc_utils.c
@@ -41,9 +41,9 @@
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_ManageTables(void)
+CFE_Status_t LC_ManageTables(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /*
     ** It is not necessary to release dump only table pointers before
@@ -110,9 +110,9 @@ int32 LC_ManageTables(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_UpdateTaskCDS(void)
+CFE_Status_t LC_UpdateTaskCDS(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /*
     ** Copy the watchpoint results table (WRT) data to CDS
@@ -164,9 +164,9 @@ int32 LC_UpdateTaskCDS(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 LC_PerformMaintenance(void)
+CFE_Status_t LC_PerformMaintenance(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /*
     ** Manage tables - allow cFE to perform dump, update, etc.

--- a/fsw/src/lc_utils.h
+++ b/fsw/src/lc_utils.h
@@ -44,7 +44,7 @@
  *
  *  \sa #LC_WDT_GETADDR_ERR_EID, #LC_ADT_GETADDR_ERR_EID
  */
-int32 LC_ManageTables(void);
+CFE_Status_t LC_ManageTables(void);
 
 /**
  * \brief Write to Critical Data Store (CDS)
@@ -60,7 +60,7 @@ int32 LC_ManageTables(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 LC_UpdateTaskCDS(void);
+CFE_Status_t LC_UpdateTaskCDS(void);
 
 /**
  * \brief Perform Routine Maintenance
@@ -82,6 +82,6 @@ int32 LC_UpdateTaskCDS(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 LC_PerformMaintenance(void);
+CFE_Status_t LC_PerformMaintenance(void);
 
 #endif

--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -77,7 +77,7 @@ void LC_CreateHashTable(void)
     CFE_SB_MsgId_t    MessageID;
     int32             MessageLinkIndex;
     int32             WatchPtTblIndex;
-    int32             Result;
+    CFE_Status_t      Result;
 
     /* Un-subscribe to any MessageID's referenced in previous Watchpoint Definition Table */
     for (MessageLinkIndex = 0; MessageLinkIndex < LC_OperData.MessageIDsCount; MessageLinkIndex++)
@@ -148,7 +148,7 @@ LC_WatchPtList_t *LC_AddWatchpoint(CFE_SB_MsgId_t MessageID)
     LC_WatchPtList_t *WatchPtLink;
     bool              NeedSubscription;
     int32             HashTableIndex;
-    int32             Result;
+    CFE_Status_t      Result;
 
     /* Hash function converts MessageID into hash table index */
     HashTableIndex = LC_GetHashTableIndex(MessageID);

--- a/unit-test/lc_app_tests.c
+++ b/unit-test/lc_app_tests.c
@@ -267,8 +267,8 @@ void LC_AppMain_Test_SbTimeout(void)
 
 void LC_AppInit_Test_Nominal(void)
 {
-    int32 Result;
-    char  Message[125];
+    CFE_Status_t Result;
+    char         Message[125];
 
     memset(&LC_OperData, 1, sizeof(LC_OperData));
     memset(&LC_AppData, 1, sizeof(LC_AppData));
@@ -330,7 +330,7 @@ void LC_AppInit_Test_Nominal(void)
 
 void LC_AppInit_Test_EVSInitError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to prevent errors when initializing tables */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Load), CFE_SUCCESS);
@@ -350,7 +350,7 @@ void LC_AppInit_Test_EVSInitError(void)
 
 void LC_AppInit_Test_SBInitError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to prevent errors when initializing tables */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Load), CFE_SUCCESS);
@@ -371,7 +371,7 @@ void LC_AppInit_Test_SBInitError(void)
 
 void LC_AppInit_Test_TableInitError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to cause LC_TableInit to return -1, in order to satisfy subsequent condition "Status != CFE_SUCCESS" */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Load), -1);
@@ -389,7 +389,7 @@ void LC_AppInit_Test_TableInitError(void)
 
 void LC_EvsInit_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Execute the function being tested */
     Result = LC_EvsInit();
@@ -403,7 +403,7 @@ void LC_EvsInit_Test_Nominal(void)
 
 void LC_EvsInit_Test_EVSRegisterError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to generate system log message "LC App: Error Registering For Event Services" */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), -1);
@@ -424,7 +424,7 @@ void LC_EvsInit_Test_EVSRegisterError(void)
 
 void LC_SbInit_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Execute the function being tested */
     Result = LC_SbInit();
@@ -438,7 +438,7 @@ void LC_SbInit_Test_Nominal(void)
 
 void LC_SbInit_Test_CreatePipeError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to generate error message LC_CR_PIPE_ERR_EID */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), -1);
@@ -459,7 +459,7 @@ void LC_SbInit_Test_CreatePipeError(void)
 
 void LC_SbInit_Test_SubscribeHKReqError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to generate error message LC_SUB_HK_REQ_ERR_EID */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_Subscribe), -1);
@@ -480,7 +480,7 @@ void LC_SbInit_Test_SubscribeHKReqError(void)
 
 void LC_SbInit_Test_SubscribeGndCmdError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to generate error message LC_SUB_GND_CMD_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -1);
@@ -501,7 +501,7 @@ void LC_SbInit_Test_SubscribeGndCmdError(void)
 
 void LC_SbInit_Test_SubscribeSampleCmdError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to generate error message LC_SUB_SAMPLE_CMD_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 3, -1);
@@ -746,7 +746,7 @@ void LC_TableInit_Test_GetADTAddressUpdated(void)
 
 void LC_TableInit_Test_CreateTaskCDSError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
     LC_OperData.HaveActiveCDS = true;
 
     /* force LC_CreateTaskCDS to fail */
@@ -760,7 +760,7 @@ void LC_TableInit_Test_CreateTaskCDSError(void)
 
 void LC_TableInit_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = true;
 
@@ -792,7 +792,7 @@ void LC_TableInit_Test_Nominal(void)
 
 void LC_CreateResultTables_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults = 0;
 
@@ -810,7 +810,7 @@ void LC_CreateResultTables_Test_Nominal(void)
 
 void LC_CreateResultTables_Test_WRTRegisterError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults = 0;
 
@@ -834,7 +834,7 @@ void LC_CreateResultTables_Test_WRTRegisterError(void)
 
 void LC_CreateResultTables_Test_WRTGetAddressError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults = 0;
 
@@ -858,7 +858,7 @@ void LC_CreateResultTables_Test_WRTGetAddressError(void)
 
 void LC_CreateResultTables_Test_ARTRegisterError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults = 0;
 
@@ -882,7 +882,7 @@ void LC_CreateResultTables_Test_ARTRegisterError(void)
 
 void LC_CreateResultTables_Test_ARTGetAddressError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults = 0;
 
@@ -906,7 +906,7 @@ void LC_CreateResultTables_Test_ARTGetAddressError(void)
 
 void LC_CreateDefinitionTables_Test_NominalCDSActive(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults  = 0;
     LC_OperData.HaveActiveCDS = true;
@@ -928,7 +928,7 @@ void LC_CreateDefinitionTables_Test_NominalCDSActive(void)
 
 void LC_CreateDefinitionTables_Test_NominalCDSInactive(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults  = 0;
     LC_OperData.HaveActiveCDS = false;
@@ -950,9 +950,9 @@ void LC_CreateDefinitionTables_Test_NominalCDSInactive(void)
 
 void LC_CreateDefinitionTables_Test_WDTReRegisterThenInfoRecovered(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error registering WDT as critical table, retrying with default options, RC=0x%%08X");
@@ -988,9 +988,9 @@ void LC_CreateDefinitionTables_Test_WDTReRegisterThenInfoRecovered(void)
 
 void LC_CreateDefinitionTables_Test_ADTReRegisterThenInfoRecovered(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error registering ADT as critical table, retrying with default options, RC=0x%%08X");
@@ -1026,7 +1026,7 @@ void LC_CreateDefinitionTables_Test_ADTReRegisterThenInfoRecovered(void)
 
 void LC_CreateDefinitionTables_Test_WDTCriticalADTNoncritical(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.TableResults  = 0;
     LC_OperData.HaveActiveCDS = false;
@@ -1105,7 +1105,7 @@ void LC_CreateDefinitionTables_Test_ADTRegisterError(void)
 
 void LC_LoadDefaultTables_Test_NominalActiveCDS(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = true;
 
@@ -1135,7 +1135,7 @@ void LC_LoadDefaultTables_Test_NominalActiveCDS(void)
 
 void LC_LoadDefaultTables_Test_ActiveCDSNotSuccess(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = true;
 
@@ -1169,7 +1169,7 @@ void LC_LoadDefaultTables_Test_ActiveCDSNotSuccess(void)
 
 void LC_LoadDefaultTables_Test_NominalInactiveCDS(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
     LC_OperData.HaveActiveCDS = false;
 
     /* Set to satisfy all instances of condition "Result == CFE_SUCCESS" after calls to CFE_TBL_Load */
@@ -1198,7 +1198,7 @@ void LC_LoadDefaultTables_Test_NominalInactiveCDS(void)
 
 void LC_LoadDefaultTables_Test_LoadWDTError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = false;
 
@@ -1221,7 +1221,7 @@ void LC_LoadDefaultTables_Test_LoadWDTError(void)
 
 void LC_LoadDefaultTables_Test_GetWDTAddressError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = false;
 
@@ -1247,7 +1247,7 @@ void LC_LoadDefaultTables_Test_GetWDTAddressError(void)
 
 void LC_LoadDefaultTables_Test_LoadADTError(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = false;
 
@@ -1294,7 +1294,7 @@ void LC_LoadDefaultTables_Test_GetADTAddressError(void)
 
 void LC_LoadDefaultTables_Test_InfoUpdated(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = true;
 
@@ -1324,7 +1324,7 @@ void LC_LoadDefaultTables_Test_InfoUpdated(void)
 
 void LC_CreateTaskCDS_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RegisterCDS), CFE_SUCCESS);
 
@@ -1344,9 +1344,9 @@ void LC_CreateTaskCDS_Test_Nominal(void)
 
 void LC_CreateTaskCDS_Test_WRTRegisterCDSError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, -1);
 
@@ -1367,9 +1367,9 @@ void LC_CreateTaskCDS_Test_WRTRegisterCDSError(void)
 
 void LC_CreateTaskCDS_Test_ARTRegisterCDSError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 2, -1);
 
@@ -1390,9 +1390,9 @@ void LC_CreateTaskCDS_Test_ARTRegisterCDSError(void)
 
 void LC_CreateTaskCDS_Test_AppDataRegisterCDSError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 3, -1);
 
@@ -1414,7 +1414,7 @@ void LC_CreateTaskCDS_Test_AppDataRegisterCDSError(void)
 
 void LC_CreateTaskCDS_Test_RestoreSuccess(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RegisterCDS), CFE_ES_CDS_ALREADY_EXISTS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RestoreFromCDS), CFE_SUCCESS);
@@ -1443,7 +1443,7 @@ void LC_CreateTaskCDS_Test_RestoreSuccess(void)
 
 void LC_CreateTaskCDS_Test_RestoreSuccessCDSNotSaved(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RegisterCDS), CFE_ES_CDS_ALREADY_EXISTS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RestoreFromCDS), CFE_SUCCESS);
@@ -1472,7 +1472,7 @@ void LC_CreateTaskCDS_Test_RestoreSuccessCDSNotSaved(void)
 
 void LC_CreateTaskCDS_Test_RestoreFail(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RegisterCDS), CFE_ES_CDS_ALREADY_EXISTS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RestoreFromCDS), -1);

--- a/unit-test/lc_cmds_tests.c
+++ b/unit-test/lc_cmds_tests.c
@@ -247,7 +247,7 @@ void LC_SampleAPReq_Test_SampleAllUpdateAgeZero(void)
 
 void LC_SendHkCmd_Test_WatchStale(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -297,7 +297,7 @@ void LC_SendHkCmd_Test_WatchStale(void)
 
 void LC_SendHkCmd_Test_WatchFalse(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -347,7 +347,7 @@ void LC_SendHkCmd_Test_WatchFalse(void)
 
 void LC_SendHkCmd_Test_WatchTrue(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -397,7 +397,7 @@ void LC_SendHkCmd_Test_WatchTrue(void)
 
 void LC_SendHkCmd_Test_WatchError(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -448,7 +448,7 @@ void LC_SendHkCmd_Test_WatchError(void)
 
 void LC_SendHkCmd_Test_DefaultWatchResult(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -498,7 +498,7 @@ void LC_SendHkCmd_Test_DefaultWatchResult(void)
 
 void LC_SendHkCmd_Test_ActionNotUsedStale(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -549,7 +549,7 @@ void LC_SendHkCmd_Test_ActionNotUsedStale(void)
 
 void LC_SendHkCmd_Test_APStateActiveActionPass(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -602,7 +602,7 @@ void LC_SendHkCmd_Test_APStateActiveActionPass(void)
 
 void LC_SendHkCmd_Test_APStatePassiveActionFail(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -653,7 +653,7 @@ void LC_SendHkCmd_Test_APStatePassiveActionFail(void)
 
 void LC_SendHkCmd_Test_APStateDisabledActionError(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -704,7 +704,7 @@ void LC_SendHkCmd_Test_APStateDisabledActionError(void)
 
 void LC_SendHkCmd_Test_APStatePermOffActionError(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -755,7 +755,7 @@ void LC_SendHkCmd_Test_APStatePermOffActionError(void)
 
 void LC_SendHkCmd_Test_DefaultCurrentStateAndActionResult(void)
 {
-    int32                     Result;
+    CFE_Status_t              Result;
     uint16                    TableIndex;
     uint16                    HKIndex;
     uint8                     ExpectedByteData;
@@ -806,7 +806,7 @@ void LC_SendHkCmd_Test_DefaultCurrentStateAndActionResult(void)
 
 void LC_SendHkCmd_Test_ManageTablesError(void)
 {
-    int32          Result;
+    CFE_Status_t   Result;
     CFE_SB_MsgId_t TestMsgId;
 
     TestMsgId = CFE_SB_ValueToMsgId(LC_SEND_HK_MID);

--- a/unit-test/lc_utils_tests.c
+++ b/unit-test/lc_utils_tests.c
@@ -40,9 +40,9 @@ uint8 call_count_CFE_EVS_SendEvent;
 
 void LC_ManageTables_Test_Nominal(void)
 {
-    int32 Result;
-    uint8 call_count_LC_ResetResultsWP;
-    uint8 call_count_LC_ResetResultsAP;
+    CFE_Status_t Result;
+    uint8        call_count_LC_ResetResultsWP;
+    uint8        call_count_LC_ResetResultsAP;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
 
@@ -64,9 +64,9 @@ void LC_ManageTables_Test_Nominal(void)
 
 void LC_ManageTables_Test_InfoUpdated(void)
 {
-    int32 Result;
-    uint8 call_count_LC_ResetResultsWP;
-    uint8 call_count_LC_ResetResultsAP;
+    CFE_Status_t Result;
+    uint8        call_count_LC_ResetResultsWP;
+    uint8        call_count_LC_ResetResultsAP;
 
     /* Set to satisfy all instances of condition "Result == CFE_TBL_INFO_UPDATED" */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
@@ -89,11 +89,11 @@ void LC_ManageTables_Test_InfoUpdated(void)
 
 void LC_ManageTables_Test_WDTGetAddressError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    uint8 call_count_LC_ResetResultsWP;
-    uint8 call_count_LC_ResetResultsAP;
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    uint8        call_count_LC_ResetResultsWP;
+    uint8        call_count_LC_ResetResultsAP;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error getting WDT address, RC=0x%%08X");
 
@@ -123,10 +123,10 @@ void LC_ManageTables_Test_WDTGetAddressError(void)
 
 void LC_ManageTables_Test_ADTGetAddressError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    uint8 call_count_LC_ResetResultsAP;
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    uint8        call_count_LC_ResetResultsAP;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error getting ADT address, RC=0x%%08X");
 
@@ -154,9 +154,9 @@ void LC_ManageTables_Test_ADTGetAddressError(void)
 
 void LC_UpdateTaskCDS_Test_UpdateWatchpointError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Unable to update watchpoint results in CDS, RC=0x%%08X");
@@ -181,9 +181,9 @@ void LC_UpdateTaskCDS_Test_UpdateWatchpointError(void)
 
 void LC_UpdateTaskCDS_Test_UpdateActionpointError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Unable to update actionpoint results in CDS, RC=0x%%08X");
@@ -207,9 +207,9 @@ void LC_UpdateTaskCDS_Test_UpdateActionpointError(void)
 
 void LC_UpdateTaskCDS_Test_UpdateAppDataError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Unable to update application data in CDS, RC=0x%%08X");
@@ -235,7 +235,7 @@ void LC_UpdateTaskCDS_Test_UpdateAppDataError(void)
 
 void LC_UpdateTaskCDS_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Execute the function being tested */
     Result = LC_UpdateTaskCDS();
@@ -250,7 +250,7 @@ void LC_UpdateTaskCDS_Test_Nominal(void)
 
 void LC_PerformMaintenance_Test_NominalNoCDS(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = false;
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
@@ -267,7 +267,7 @@ void LC_PerformMaintenance_Test_NominalNoCDS(void)
 
 void LC_PerformMaintenance_Test_NominalCDS(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = true;
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
@@ -284,7 +284,7 @@ void LC_PerformMaintenance_Test_NominalCDS(void)
 
 void LC_PerformMaintenance_Test_UpdateCDSFail(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = true;
 
@@ -305,7 +305,7 @@ void LC_PerformMaintenance_Test_UpdateCDSFail(void)
 
 void LC_PerformMaintenance_Test_ManageTablesFail(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     LC_OperData.HaveActiveCDS = false;
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);

--- a/unit-test/stubs/lc_app_stubs.c
+++ b/unit-test/stubs/lc_app_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for LC_AppInit()
  * ----------------------------------------------------
  */
-int32 LC_AppInit(void)
+CFE_Status_t LC_AppInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_AppInit, int32);
+    UT_GenStub_SetupReturnBuffer(LC_AppInit, CFE_Status_t);
 
     UT_GenStub_Execute(LC_AppInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_AppInit, int32);
+    return UT_GenStub_GetReturnValue(LC_AppInit, CFE_Status_t);
 }
 
 /*
@@ -56,13 +56,13 @@ void LC_AppMain(void)
  * Generated stub function for LC_CreateDefinitionTables()
  * ----------------------------------------------------
  */
-int32 LC_CreateDefinitionTables(void)
+CFE_Status_t LC_CreateDefinitionTables(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_CreateDefinitionTables, int32);
+    UT_GenStub_SetupReturnBuffer(LC_CreateDefinitionTables, CFE_Status_t);
 
     UT_GenStub_Execute(LC_CreateDefinitionTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_CreateDefinitionTables, int32);
+    return UT_GenStub_GetReturnValue(LC_CreateDefinitionTables, CFE_Status_t);
 }
 
 /*
@@ -70,13 +70,13 @@ int32 LC_CreateDefinitionTables(void)
  * Generated stub function for LC_CreateResultTables()
  * ----------------------------------------------------
  */
-int32 LC_CreateResultTables(void)
+CFE_Status_t LC_CreateResultTables(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_CreateResultTables, int32);
+    UT_GenStub_SetupReturnBuffer(LC_CreateResultTables, CFE_Status_t);
 
     UT_GenStub_Execute(LC_CreateResultTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_CreateResultTables, int32);
+    return UT_GenStub_GetReturnValue(LC_CreateResultTables, CFE_Status_t);
 }
 
 /*
@@ -84,13 +84,13 @@ int32 LC_CreateResultTables(void)
  * Generated stub function for LC_CreateTaskCDS()
  * ----------------------------------------------------
  */
-int32 LC_CreateTaskCDS(void)
+CFE_Status_t LC_CreateTaskCDS(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_CreateTaskCDS, int32);
+    UT_GenStub_SetupReturnBuffer(LC_CreateTaskCDS, CFE_Status_t);
 
     UT_GenStub_Execute(LC_CreateTaskCDS, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_CreateTaskCDS, int32);
+    return UT_GenStub_GetReturnValue(LC_CreateTaskCDS, CFE_Status_t);
 }
 
 /*
@@ -98,13 +98,13 @@ int32 LC_CreateTaskCDS(void)
  * Generated stub function for LC_EvsInit()
  * ----------------------------------------------------
  */
-int32 LC_EvsInit(void)
+CFE_Status_t LC_EvsInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_EvsInit, int32);
+    UT_GenStub_SetupReturnBuffer(LC_EvsInit, CFE_Status_t);
 
     UT_GenStub_Execute(LC_EvsInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_EvsInit, int32);
+    return UT_GenStub_GetReturnValue(LC_EvsInit, CFE_Status_t);
 }
 
 /*
@@ -112,13 +112,13 @@ int32 LC_EvsInit(void)
  * Generated stub function for LC_LoadDefaultTables()
  * ----------------------------------------------------
  */
-int32 LC_LoadDefaultTables(void)
+CFE_Status_t LC_LoadDefaultTables(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_LoadDefaultTables, int32);
+    UT_GenStub_SetupReturnBuffer(LC_LoadDefaultTables, CFE_Status_t);
 
     UT_GenStub_Execute(LC_LoadDefaultTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_LoadDefaultTables, int32);
+    return UT_GenStub_GetReturnValue(LC_LoadDefaultTables, CFE_Status_t);
 }
 
 /*
@@ -126,13 +126,13 @@ int32 LC_LoadDefaultTables(void)
  * Generated stub function for LC_SbInit()
  * ----------------------------------------------------
  */
-int32 LC_SbInit(void)
+CFE_Status_t LC_SbInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_SbInit, int32);
+    UT_GenStub_SetupReturnBuffer(LC_SbInit, CFE_Status_t);
 
     UT_GenStub_Execute(LC_SbInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_SbInit, int32);
+    return UT_GenStub_GetReturnValue(LC_SbInit, CFE_Status_t);
 }
 
 /*
@@ -140,11 +140,11 @@ int32 LC_SbInit(void)
  * Generated stub function for LC_TableInit()
  * ----------------------------------------------------
  */
-int32 LC_TableInit(void)
+CFE_Status_t LC_TableInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_TableInit, int32);
+    UT_GenStub_SetupReturnBuffer(LC_TableInit, CFE_Status_t);
 
     UT_GenStub_Execute(LC_TableInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_TableInit, int32);
+    return UT_GenStub_GetReturnValue(LC_TableInit, CFE_Status_t);
 }

--- a/unit-test/stubs/lc_cmds_stubs.c
+++ b/unit-test/stubs/lc_cmds_stubs.c
@@ -130,15 +130,15 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for LC_SendHkCmd()
  * ----------------------------------------------------
  */
-int32 LC_SendHkCmd(const CFE_MSG_CommandHeader_t *MsgPtr)
+CFE_Status_t LC_SendHkCmd(const CFE_MSG_CommandHeader_t *MsgPtr)
 {
-    UT_GenStub_SetupReturnBuffer(LC_SendHkCmd, int32);
+    UT_GenStub_SetupReturnBuffer(LC_SendHkCmd, CFE_Status_t);
 
     UT_GenStub_AddParam(LC_SendHkCmd, const CFE_MSG_CommandHeader_t *, MsgPtr);
 
     UT_GenStub_Execute(LC_SendHkCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_SendHkCmd, int32);
+    return UT_GenStub_GetReturnValue(LC_SendHkCmd, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/lc_dispatch_stubs.c
+++ b/unit-test/stubs/lc_dispatch_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for LC_AppPipe()
  * ----------------------------------------------------
  */
-int32 LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(LC_AppPipe, int32);
+    UT_GenStub_SetupReturnBuffer(LC_AppPipe, CFE_Status_t);
 
     UT_GenStub_AddParam(LC_AppPipe, const CFE_SB_Buffer_t *, BufPtr);
 
     UT_GenStub_Execute(LC_AppPipe, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_AppPipe, int32);
+    return UT_GenStub_GetReturnValue(LC_AppPipe, CFE_Status_t);
 }

--- a/unit-test/stubs/lc_utils_stubs.c
+++ b/unit-test/stubs/lc_utils_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for LC_ManageTables()
  * ----------------------------------------------------
  */
-int32 LC_ManageTables(void)
+CFE_Status_t LC_ManageTables(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_ManageTables, int32);
+    UT_GenStub_SetupReturnBuffer(LC_ManageTables, CFE_Status_t);
 
     UT_GenStub_Execute(LC_ManageTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_ManageTables, int32);
+    return UT_GenStub_GetReturnValue(LC_ManageTables, CFE_Status_t);
 }
 
 /*
@@ -45,13 +45,13 @@ int32 LC_ManageTables(void)
  * Generated stub function for LC_PerformMaintenance()
  * ----------------------------------------------------
  */
-int32 LC_PerformMaintenance(void)
+CFE_Status_t LC_PerformMaintenance(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_PerformMaintenance, int32);
+    UT_GenStub_SetupReturnBuffer(LC_PerformMaintenance, CFE_Status_t);
 
     UT_GenStub_Execute(LC_PerformMaintenance, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_PerformMaintenance, int32);
+    return UT_GenStub_GetReturnValue(LC_PerformMaintenance, CFE_Status_t);
 }
 
 /*
@@ -59,11 +59,11 @@ int32 LC_PerformMaintenance(void)
  * Generated stub function for LC_UpdateTaskCDS()
  * ----------------------------------------------------
  */
-int32 LC_UpdateTaskCDS(void)
+CFE_Status_t LC_UpdateTaskCDS(void)
 {
-    UT_GenStub_SetupReturnBuffer(LC_UpdateTaskCDS, int32);
+    UT_GenStub_SetupReturnBuffer(LC_UpdateTaskCDS, CFE_Status_t);
 
     UT_GenStub_Execute(LC_UpdateTaskCDS, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(LC_UpdateTaskCDS, int32);
+    return UT_GenStub_GetReturnValue(LC_UpdateTaskCDS, CFE_Status_t);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #90
  - most `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`
  - removed the `Status` variable from `LC_AppPipe()` - it was not actually used - the function always returns `CFE_SUCCESS` as currently implemented

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt