### PR TITLE
Fix #95, add local isnan, isfinite macros

### DIFF
--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -32,7 +32,26 @@
 #include "lc_perfids.h"
 #include "lc_platform_cfg.h"
 
+#include <float.h>
 #include <math.h>
+
+/*
+ * An ISO-compliant math.h header should provide "isnan" and "isfinite" macros
+ * as they are dicatated by C99.  However some C libraries still in use are not
+ * fully compliant.  If these macros are not defined, define a substitute here.
+ *
+ * Note these are not ideal/complete implementations of these macros, but they
+ * are OK based on the way they are used inside this source file.  Use caution if
+ * changing the code using these, notably:
+ *  - isfinite assumes float type
+ *  - both macros evaluate the argument twice - use only with a simple variable
+ */
+#ifndef isnan
+#define isnan(x) ((x) != (x))
+#endif
+#ifndef isfinite
+#define isfinite(x) ((x) > -FLT_MAX && (x) < FLT_MAX)
+#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
In case the system-provided math.h header does not provide an implementation if isnan or isfinite, use a local workaround.

Fixes #95

**Testing performed**
Build on VxWorks 6.9

**Expected behavior changes**
Build is successful

**System(s) tested on**
VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.