### PR TITLE
Fix #97, Support custom override of lc_msgids

### DIFF
--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -19,7 +19,13 @@ set(LC_PLATFORM_CONFIG_FILE_LIST
 # This makes them individually overridable by the missions, without modifying
 # the distribution default copies
 foreach(LC_CFGFILE ${LC_PLATFORM_CONFIG_FILE_LIST})
-  set(DEFAULT_SOURCE "${CMAKE_CURRENT_LIST_DIR}/config/default_${LC_CFGFILE}")
+   get_filename_component(CFGKEY "${LC_CFGFILE}" NAME_WE) 
+   if (DEFINED LC_CFGFILE_SRC_${CFGKEY}) 
+     set(DEFAULT_SOURCE "${LC_CFGFILE_SRC_${CFGKEY}}") 
+   else() 
+     set(DEFAULT_SOURCE "${CMAKE_CURRENT_LIST_DIR}/config/default_${LC_CFGFILE}") 
+   endif()
+
   generate_config_includefile(
     FILE_NAME           "${LC_CFGFILE}"
     FALLBACK_FILE       "${DEFAULT_SOURCE}"


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #97 

**Testing performed**
CI

**Expected behavior changes**
Supports override of msgids from a single file

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC