### PR TITLE
Fix #99, Add padding in LC_RTSRequest_Payload_t to match SC

### DIFF
--- a/config/default_lc_msgstruct.h
+++ b/config/default_lc_msgstruct.h
@@ -230,7 +230,8 @@ typedef struct
  */
 typedef struct
 {
-    uint16 RTSId; /**< \brief RTS Id to start */
+    uint16 RTSId;   /**< \brief RTS Id to start */
+    uint16 Padding; /**< \brief Padding */
 } LC_RTSRequest_Payload_t;
 
 /**


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #99 

Note this does nothing to address the dependencies on SC (see #100), or functional testing that should confirm this actually works.

**Testing performed**
Ran in custom build with SC and confirmed Start RTS command worked.

**Expected behavior changes**
Start RTS works.

**System(s) tested on**
Ubuntu 22 docker

**Additional context**
This does not attempt to address the bigger issues that led to this bug.  See:
- #100

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC