### PR TITLE
Fix #108, Removes cfe platform config dependency

### DIFF
--- a/fsw/src/lc_app.c
+++ b/fsw/src/lc_app.c
@@ -37,7 +37,6 @@
 #include "lc_action.h"
 #include "lc_watch.h"
 #include "lc_utils.h"
-#include "cfe_platform_cfg.h"
 #include "lc_platform_cfg.h"
 #include "lc_mission_cfg.h" /* Leave these two last to make sure all   */
 #include "lc_verify.h"      /* LC configuration parameters are checked */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #108, removes deprecated dependency of cfe platform configuration.

**Testing performed**
local machine build app, lcov

**Expected behavior changes**
N/A

**System(s) tested on**
 -OS: Ubuntu 20.04

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
