### PR TITLE
Fix #111, Update LC_RESET_DBG_EID to be informational

### DIFF
--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -282,7 +282,7 @@ void LC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     LC_ResetCounters();
 
-    CFE_EVS_SendEvent(LC_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(LC_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset counters command");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
Fix #111, update LC_RESET_DBG_EID to be informational event instead of debug

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]
- 
Fixes #111, update reset command events to be infomational instead of debug

**Testing performed**
Steps taken to test the contribution:
1. make SIMULATION=native prep
2. Make install
3. Verify it works 

4. Make SIMULATION=native ENABLE_UNIT_TESTS=true prep
5. make 
6. make test
7. make lcov
8. Verify all test still pass/lcov is 100%

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
Anh Van, GSFC