### PR TITLE
Fix #8, do not update `LastFalseToTrue` + `LastTrueToFalse` when transitioning from `STALE`

### DIFF
--- a/fsw/src/lc_watch.c
+++ b/fsw/src/lc_watch.c
@@ -409,7 +409,7 @@ void LC_ProcessWP(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr, CFE_TIME_Sys
             StaleCounter                                    = LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale;
             LC_OperData.WRTPtr[WatchIndex].CountdownToStale = StaleCounter;
 
-            if ((PreviousResult == LC_WATCH_FALSE) || (PreviousResult == LC_WATCH_STALE))
+            if (PreviousResult == LC_WATCH_FALSE)
             {
                 LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.DataType = LC_OperData.WDTPtr[WatchIndex].DataType;
 
@@ -428,7 +428,7 @@ void LC_ProcessWP(uint16 WatchIndex, const CFE_SB_Buffer_t *BufPtr, CFE_TIME_Sys
             StaleCounter                                        = LC_OperData.WDTPtr[WatchIndex].ResultAgeWhenStale;
             LC_OperData.WRTPtr[WatchIndex].CountdownToStale     = StaleCounter;
 
-            if ((PreviousResult == LC_WATCH_TRUE) || (PreviousResult == LC_WATCH_STALE))
+            if (PreviousResult == LC_WATCH_TRUE)
             {
                 LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.DataType = LC_OperData.WDTPtr[WatchIndex].DataType;
 

--- a/unit-test/lc_watch_tests.c
+++ b/unit-test/lc_watch_tests.c
@@ -421,6 +421,11 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale(void)
     LC_OperData.WDTPtr[WatchIndex].ComparisonValue.Signed8 = 1;
     LC_OperData.WRTPtr[WatchIndex].EvaluationCount         = 0;
 
+    /* Initialize LastFalseToTrue to verify that it doesn't get modified */
+    LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Value                = 0xCC;
+    LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Seconds    = 55;
+    LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds = 44;
+
     /* Execute the function being tested */
     LC_ProcessWP(WatchIndex, &UT_CmdBuf.Buf, Timestamp);
 
@@ -437,14 +442,16 @@ void LC_ProcessWP_Test_OperatorCompareWatchTruePreviousStale(void)
     UtAssert_True(LC_OperData.WRTPtr[WatchIndex].CountdownToStale == 1,
                   "LC_OperData.WRTPtr[WatchIndex].CountdownToStale == 1");
 
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].FalseToTrueCount == 1,
-                  "LC_OperData.WRTPtr[WatchIndex].FalseToTrueCount == 1");
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Value == 0,
-                  "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Value == 0");
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Seconds == 3,
-                  "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Seconds == 3");
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds == 5,
-                  "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds == 5");
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].FalseToTrueCount == 0,
+                  "LC_OperData.WRTPtr[WatchIndex].FalseToTrueCount == 0");
+
+    /* Verify that LastFalseToTrue Value and Timestamp weren't modified */
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Value == 0xCC,
+                  "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Value == 0xCC (unchanged)");
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Seconds == 55,
+                  "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Seconds == 55 (unchanged)");
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds == 44,
+                  "LC_OperData.WRTPtr[WatchIndex].LastFalseToTrue.Timestamp.Subseconds == 44 (unchanged)");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
 }
@@ -500,10 +507,10 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
 {
     uint16             WatchIndex = 0;
     CFE_TIME_SysTime_t Timestamp;
-    CFE_SB_MsgId_t     TestMsgId = LC_UT_MID_1;
 
     Timestamp.Seconds    = 3;
     Timestamp.Subseconds = 5;
+    CFE_SB_MsgId_t TestMsgId = LC_UT_MID_1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -514,6 +521,11 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
     LC_OperData.WDTPtr[WatchIndex].BitMask                 = 0;
     LC_OperData.WDTPtr[WatchIndex].ComparisonValue.Signed8 = 1;
     LC_OperData.WRTPtr[WatchIndex].EvaluationCount         = 0;
+
+    /* Initialize LastTrueToFalse to verify that it doesn't get modified */
+    LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Value                = 0xBB;
+    LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Seconds    = 77;
+    LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds = 66;
 
     /* Execute the function being tested */
     LC_ProcessWP(WatchIndex, &UT_CmdBuf.Buf, Timestamp);
@@ -529,12 +541,13 @@ void LC_ProcessWP_Test_OperatorCompareWatchFalsePreviousStale(void)
     UtAssert_True(LC_OperData.WRTPtr[WatchIndex].CountdownToStale == 1,
                   "LC_OperData.WRTPtr[WatchIndex].CountdownToStale == 1");
 
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Value == 0,
-                  "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Value == 0");
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Seconds == 3,
-                  "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Seconds == 3");
-    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds == 5,
-                  "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds == 5");
+    /* Verify that LastTrueToFalse Value and Timestamp weren't modified */
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Value == 0xBB,
+                  "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Value == 0xBB (unchanged)");
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Seconds == 77,
+                  "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Seconds == 77 (unchanged)");
+    UtAssert_True(LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds == 66,
+                  "LC_OperData.WRTPtr[WatchIndex].LastTrueToFalse.Timestamp.Subseconds == 66 (unchanged)");
 
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0, "UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)) == 0");
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #8 
  - removes `|| (PreviousResult == LC_WATCH_STALE)` to avoid entering the update block if transitioning from `FALSE` (so we only enter the block when `WPEvalResult == ...TRUE`)
  - updates the relevant tests and adds test logic to confirm this behavior in future (and catch if the bug is re-introduced)

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).  
100% coverage is maintained.

**Expected behavior changes**
As above.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt