### PR TITLE
Fix #76, add LC_SAMPLE_AP_ALL_MID

### DIFF
--- a/config/default_lc_msgids.h
+++ b/config/default_lc_msgids.h
@@ -29,9 +29,10 @@
  * \{
  */
 
-#define LC_CMD_MID       0x18A4 /**< \brief Msg ID for cmds to LC                */
-#define LC_SEND_HK_MID   0x18A5 /**< \brief Msg ID to request LC housekeeping    */
-#define LC_SAMPLE_AP_MID 0x18A6 /**< \brief Msg ID to request actionpoint sample */
+#define LC_CMD_MID           0x18A4 /**< \brief Msg ID for cmds to LC                */
+#define LC_SEND_HK_MID       0x18A5 /**< \brief Msg ID to request LC housekeeping    */
+#define LC_SAMPLE_AP_MID     0x18A6 /**< \brief Msg ID to request actionpoint sample */
+#define LC_SAMPLE_AP_ALL_MID 0x18A7 /**< \brief Msg ID to sample all actionpoints    */
 
 /**\}*/
 

--- a/config/default_lc_msgstruct.h
+++ b/config/default_lc_msgstruct.h
@@ -226,6 +226,16 @@ typedef struct
 } LC_SampleAPCmd_t;
 
 /**
+ *  \brief Sample All APs (Actionpoints) Request
+ *
+ *  See #LC_SAMPLE_AP_ALL_MID
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
+} LC_SampleAllAPsCmd_t;
+
+/**
  * \brief Payload to Start a Stored Command RTS
  */
 typedef struct

--- a/docs/dox_src/cfs_lc.dox
+++ b/docs/dox_src/cfs_lc.dox
@@ -135,8 +135,8 @@
   or more watchpoints. Actionpoints are defined in the Actionpoint Definition Table (ADT).
   Statistics on actionpoint evaluations are stored in the Actionpoint Results Table (ART)
   (see \ref cfslctbl). Actionpoints are evaluated whenever LC receives a message with
-  the #LC_SAMPLE_AP_MID message ID. This is not a ground command but an internal message
-  that will normally come from the CFS scheduler (SCH) application.
+  the #LC_SAMPLE_AP_MID or #LC_SAMPLE_AP_ALL_MID message ID. These are not ground commands but
+  internal messages that will normally come from the CFS scheduler (SCH) application.
 
   \image html LC_Context.png "LC Context Diagram"
   \image latex LC_Context.png "LC Context Diagram"
@@ -165,12 +165,14 @@
   Watchpoints from being evaluated are to squelch the telemetry packet on which they trigger,
   load a WDT that undefines a Watchpoint or disable the entire LC task.
 
-  Actionpoints are evaluated whenever LC receives a message with the #LC_SAMPLE_AP_MID message
-  ID. This message contains a parameter indicating which actionpoint to evaluate. A single
-  actionpoint can be specified by using the actionpoint ID (0 to #LC_MAX_ACTIONPOINTS). All
-  actionpoints can be evaluated by specifying xFFFF as the parameter. There is no way to evaluate
-  multiple actionpoints other than ALL within a single message. An Actionpoint defines a logical
-  relationship between one or more Watchpoint results.
+  Actionpoints are evaluated whenever LC receives a message with the #LC_SAMPLE_AP_MID or
+  #LC_SAMPLE_AP_ALL_MID message ID. The #LC_SAMPLE_AP_MID message contains a parameter indicating
+  which actionpoint to evaluate. A single actionpoint can be specified by using the actionpoint ID
+  (0 to #LC_MAX_ACTIONPOINTS-1). All actionpoints can be evaluated by specifying xFFFF as the
+  parameter. The #LC_SAMPLE_AP_ALL_MID message has no parameters and will evaluate all actionpoints
+  (equivalent to using #LC_SAMPLE_AP_MID with xFFFF). An Actionpoint defines a logical relationship
+  between one or more Watchpoint results. There is no way to evaluate multiple actionpoints other
+  than ALL within a single message.
 
   This logical relationship is defined in the form of a Reverse Polish Notation (RPN)
   expression in the actionpoint definition specified in the ADT. The result of this RPN
@@ -241,9 +243,11 @@
   Example source code for these tables sized to the default number of watchpoints
   and actionpoints are provided in the files lc_def_wdt.c and lc_def_adt.c.
 
-  LC requires a message with the message ID #LC_SAMPLE_AP_MID to sample actionpoints.
-  The CFS scheduler application (SCH) needs to be configured to provide this trigger
-  message at the desired frequency for actionpoint processing to occur.
+  LC requires a message with the message ID #LC_SAMPLE_AP_MID or #LC_SAMPLE_AP_ALL_MID
+  to sample actionpoints. The CFS scheduler application (SCH) needs to be configured to
+  provide these trigger messages at the desired frequency for actionpoint processing to occur.
+  Use #LC_SAMPLE_AP_MID with a parameter to sample specific actionpoints, or
+  #LC_SAMPLE_AP_ALL_MID (no parameters) to sample all actionpoints.
 
   The function #LC_ExecuteRTS in the file lc_custom.c needs to be reviewed for any
   modifications that may be needed to properly initiate RTS responses to actionpoint
@@ -637,8 +641,9 @@
   <B> (Q)
      Can I send a single actionpoint evaluation message for multiple actionpoints (eg. 1,2,5,6,7)?
   </B> <BR> <BR> <I>
-     No. You can send individual messages for each action point or a single message to evaluate
-     ALL (xFFFF) actionpoints.
+     No. You can send individual messages for each action point using #LC_SAMPLE_AP_MID, or
+     evaluate ALL actionpoints using either #LC_SAMPLE_AP_MID with xFFFF as the parameter or
+     #LC_SAMPLE_AP_ALL_MID which requires no parameters.
   </I>
 
   <B> (Q)

--- a/fsw/inc/lc_eventids.h
+++ b/fsw/inc/lc_eventids.h
@@ -108,6 +108,19 @@
 #define LC_SUB_SAMPLE_CMD_ERR_EID 6
 
 /**
+ * \brief LC Subscribe To Sample All Actionpoints Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  This event message is issued when the CFS Limit Checker
+ *  is unable to subscribe to its sample all actionpoints command via the
+ *  #CFE_SB_Subscribe API
+ */
+#define LC_SUB_SAMPLE_ALL_CMD_ERR_EID 7
+
+/**
  * \brief LC Watchpoint Definition Table Registration Failed Event ID
  *
  *  \par Type: ERROR
@@ -117,7 +130,7 @@
  *  This event message is issued when the watchpoint definition
  *  table (WDT) could not be registered.
  */
-#define LC_WDT_REGISTER_ERR_EID 7
+#define LC_WDT_REGISTER_ERR_EID 8
 
 /**
  * \brief LC Watchpoint Definition Table Reregistration Failed Event ID
@@ -133,7 +146,7 @@
  *  ADT fails the attempt to register as a critical table. This
  *  error is extremely unlikely to occur.
  */
-#define LC_WDT_REREGISTER_ERR_EID 8
+#define LC_WDT_REREGISTER_ERR_EID 9
 
 /**
  * \brief LC Actionpoint Definition Table Registration Failed Event ID
@@ -145,7 +158,7 @@
  *  This event message is issued when the actionpoint definition
  *  table (ADT) could not be registered.
  */
-#define LC_ADT_REGISTER_ERR_EID 9
+#define LC_ADT_REGISTER_ERR_EID 10
 
 /**
  * \brief LC Watchpoint Results Table Registration Failed Event ID
@@ -157,7 +170,7 @@
  *  This event message is issued when the watchpoint results
  *  table (WRT) could not be registered.
  */
-#define LC_WRT_REGISTER_ERR_EID 10
+#define LC_WRT_REGISTER_ERR_EID 11
 
 /**
  * \brief LC Actionpoint Results Table Registration Failed Event ID
@@ -169,7 +182,7 @@
  *  This event message is issued when the actionpoint results
  *  table (ART) could not be registered.
  */
-#define LC_ART_REGISTER_ERR_EID 11
+#define LC_ART_REGISTER_ERR_EID 12
 
 /**
  * \brief LC Watchpoint Result Table CDS Registration Failed Event ID
@@ -181,7 +194,7 @@
  *  This event message is issued when the CDS area for the
  *  watchpoint results table (WRT) data could not be registered.
  */
-#define LC_WRT_CDS_REGISTER_ERR_EID 12
+#define LC_WRT_CDS_REGISTER_ERR_EID 13
 
 /**
  * \brief LC Actionpoint Result Table CDS Registration Failed Event ID
@@ -193,7 +206,7 @@
  *  This event message is issued when the CDS area for the
  *  actionpont results table (ART) data could not be registered.
  */
-#define LC_ART_CDS_REGISTER_ERR_EID 13
+#define LC_ART_CDS_REGISTER_ERR_EID 14
 
 /**
  * \brief LC Application Data CDS Registration Failed Event ID
@@ -205,7 +218,7 @@
  *  This event message is issued when the CDS area for the
  *  LC application data could not be registered.
  */
-#define LC_APP_CDS_REGISTER_ERR_EID 14
+#define LC_APP_CDS_REGISTER_ERR_EID 15
 
 /**
  * \brief LC Watchpoint Definition Table Load From File Failed Event ID
@@ -218,7 +231,7 @@
  *  loading the watchpoint definition table (WDT) from the default
  *  file image
  */
-#define LC_WDT_LOAD_ERR_EID 15
+#define LC_WDT_LOAD_ERR_EID 16
 
 /**
  * \brief LC Actionpoint Definition Table Load From File Failed Event ID
@@ -231,7 +244,7 @@
  *  loading the actionpoint definition table (ADT) from the default
  *  file image
  */
-#define LC_ADT_LOAD_ERR_EID 16
+#define LC_ADT_LOAD_ERR_EID 17
 
 /**
  * \brief LC Watchpoint Result Table Get Address Failed Event ID
@@ -243,7 +256,7 @@
  *  This event message is issued when the address can't be obtained
  *  from table services for the watchpoint results table (WRT).
  */
-#define LC_WRT_GETADDR_ERR_EID 17
+#define LC_WRT_GETADDR_ERR_EID 18
 
 /**
  * \brief LC Actionpoint Result Table Get Address Failed Event ID
@@ -255,7 +268,7 @@
  *  This event message is issued when the address can't be obtained
  *  from table services for the actionpoint results table (ART).
  */
-#define LC_ART_GETADDR_ERR_EID 18
+#define LC_ART_GETADDR_ERR_EID 19
 
 /**
  * \brief LC Watchpoint Definition Table Get Address Failed Event ID
@@ -267,7 +280,7 @@
  *  This event message is issued when the address can't be obtained
  *  from table services for the watchpoint definition table (WDT).
  */
-#define LC_WDT_GETADDR_ERR_EID 19
+#define LC_WDT_GETADDR_ERR_EID 20
 
 /**
  * \brief LC Actionpoint Definition Table Get Address Failed Event ID
@@ -279,7 +292,7 @@
  *  This event message is issued when the address can't be obtained
  *  from table services for the actionpoint definition table (ADT).
  */
-#define LC_ADT_GETADDR_ERR_EID 20
+#define LC_ADT_GETADDR_ERR_EID 21
 
 /**
  * \brief LC State Restored From CDS Event ID
@@ -301,7 +314,7 @@
  *
  *  \sa LC_SAVE_TO_CDS, #LC_CDS_UPDATED_INF_EID, #LC_CDS_DISABLED_INF_EID
  */
-#define LC_CDS_RESTORED_INF_EID 21
+#define LC_CDS_RESTORED_INF_EID 22
 
 /**
  * \brief LC Default State Initialized and Stored to CDS Event ID
@@ -329,7 +342,7 @@
  *
  *  \sa LC_SAVE_TO_CDS, #LC_CDS_RESTORED_INF_EID, #LC_CDS_DISABLED_INF_EID
  */
-#define LC_CDS_UPDATED_INF_EID 22
+#define LC_CDS_UPDATED_INF_EID 23
 
 /**
  * \brief LC Use Of CDS Disabled Event ID
@@ -354,7 +367,7 @@
  *
  *  \sa LC_SAVE_TO_CDS, #LC_CDS_RESTORED_INF_EID, #LC_CDS_UPDATED_INF_EID
  */
-#define LC_CDS_DISABLED_INF_EID 23
+#define LC_CDS_DISABLED_INF_EID 24
 
 /**
  * \brief LC Command Code Invalid Event ID
@@ -366,7 +379,7 @@
  *  This event message is issued when a software bus message is received
  *  with an invalid command code.
  */
-#define LC_CC_ERR_EID 24
+#define LC_CC_ERR_EID 25
 
 /**
  * \brief LC Sample Actionpoint Message Start Or End Number Invalid Event ID
@@ -378,7 +391,7 @@
  *  This event message is issued when the #LC_SAMPLE_AP_MID message
  *  has been received with an invalid actionpoint start or end number specified
  */
-#define LC_APSAMPLE_APNUM_ERR_EID 25
+#define LC_APSAMPLE_APNUM_ERR_EID 26
 
 /**
  * \brief LC No-op Command Event ID
@@ -389,7 +402,7 @@
  *
  *  This event message is issued when a NOOP command has been received.
  */
-#define LC_NOOP_INF_EID 26
+#define LC_NOOP_INF_EID 27
 
 /**
  * \brief LC Reset Counters Command Event ID
@@ -401,7 +414,7 @@
  *  This event message is issued when a reset counters command has
  *  been received.
  */
-#define LC_RESET_INF_EID 27
+#define LC_RESET_INF_EID 28
 
 /**
  * \brief LC Set Limit Checker State Command Event ID
@@ -413,7 +426,7 @@
  *  This event message is issued when the #LC_SET_LC_STATE_CC command
  *  has been successfully executed
  */
-#define LC_LCSTATE_INF_EID 28
+#define LC_LCSTATE_INF_EID 29
 
 /**
  * \brief LC Set Limit Checker State, State Invalid Event ID
@@ -425,7 +438,7 @@
  *  This event message is issued when the #LC_SET_LC_STATE_CC command
  *  has been received with an invalid state argument specified
  */
-#define LC_LCSTATE_ERR_EID 29
+#define LC_LCSTATE_ERR_EID 30
 
 /**
  * \brief LC Set Actionpoint State New State Invalid Event ID
@@ -437,7 +450,7 @@
  *  This event message is issued when the #LC_SET_AP_STATE_CC command
  *  has been received with an invalid state argument specified
  */
-#define LC_APSTATE_NEW_ERR_EID 30
+#define LC_APSTATE_NEW_ERR_EID 31
 
 /**
  * \brief LC Set Actionpoint State Current State Invalid Event ID
@@ -451,7 +464,7 @@
  *  #LC_APSTATE_NOT_USED or #LC_APSTATE_PERMOFF which can only be changed
  *  with a table load.
  */
-#define LC_APSTATE_CURR_ERR_EID 31
+#define LC_APSTATE_CURR_ERR_EID 32
 
 /**
  * \brief LC Set Actionpoint State Actionpoint Number Invalid Event ID
@@ -463,7 +476,7 @@
  *  This event message is issued when the #LC_SET_AP_STATE_CC command
  *  has been received with an invalid actionpoint number specified
  */
-#define LC_APSTATE_APNUM_ERR_EID 32
+#define LC_APSTATE_APNUM_ERR_EID 33
 
 /**
  * \brief LC Set Actionpoint State Command Event ID
@@ -475,7 +488,7 @@
  *  This event message is issued when the #LC_SET_AP_STATE_CC command
  *  has been successfully executed
  */
-#define LC_APSTATE_INF_EID 33
+#define LC_APSTATE_INF_EID 34
 
 /**
  * \brief LC Set Actionpoint Permanently Off Actionpoint Number Invalid Event ID
@@ -487,7 +500,7 @@
  *  This event message is issued when the #LC_SET_AP_PERM_OFF_CC command
  *  has been received with an invalid actionpoint number specified
  */
-#define LC_APOFF_APNUM_ERR_EID 34
+#define LC_APOFF_APNUM_ERR_EID 35
 
 /**
  * \brief LC Set Actionpoint Permanently Off Actionpoint Not Disabled Event ID
@@ -500,7 +513,7 @@
  *  has been received and the current actionpoint state is not
  *  #LC_APSTATE_DISABLED
  */
-#define LC_APOFF_CURR_ERR_EID 35
+#define LC_APOFF_CURR_ERR_EID 36
 
 /**
  * \brief LC Set Actionpoint Permanently Off Command Event ID
@@ -512,7 +525,7 @@
  *  This event message is issued when the #LC_SET_AP_PERM_OFF_CC command
  *  has been successfully executed
  */
-#define LC_APOFF_INF_EID 36
+#define LC_APOFF_INF_EID 37
 
 /**
  * \brief LC Reset Actionpoint Stats Actionpoint Number Invalid Event ID
@@ -524,7 +537,7 @@
  *  This event message is issued when the #LC_RESET_AP_STATS_CC command
  *  has been received with an invalid actionpoint number specified
  */
-#define LC_APSTATS_APNUM_ERR_EID 37
+#define LC_APSTATS_APNUM_ERR_EID 38
 
 /**
  * \brief LC Reset Actionpoint Stats Command Event ID
@@ -536,7 +549,7 @@
  *  This event message is issued when the #LC_RESET_AP_STATS_CC command
  *  has been successfully executed
  */
-#define LC_APSTATS_INF_EID 38
+#define LC_APSTATS_INF_EID 39
 
 /**
  * \brief LC Reset Watchpoint Stats Watchpoint Number Invalid Event ID
@@ -548,7 +561,7 @@
  *  This event message is issued when the #LC_RESET_WP_STATS_CC command
  *  has been received with an invalid watchpoint number specified
  */
-#define LC_WPSTATS_WPNUM_ERR_EID 39
+#define LC_WPSTATS_WPNUM_ERR_EID 40
 
 /**
  * \brief LC Reset Watchpoint Stats Command Event ID
@@ -560,7 +573,7 @@
  *  This event message is issued when the #LC_RESET_WP_STATS_CC command
  *  has been successfully executed
  */
-#define LC_WPSTATS_INF_EID 40
+#define LC_WPSTATS_INF_EID 41
 
 /**
  * \brief LC Housekeeping Request Message Length Invalid Event ID
@@ -572,7 +585,7 @@
  *  This event message is issued when a housekeeping request is received
  *  with a message length that doesn't match the expected value.
  */
-#define LC_HKREQ_LEN_ERR_EID 41
+#define LC_HKREQ_LEN_ERR_EID 42
 
 /**
  * \brief LC Actionpoint Sample Message Length Invalid Event ID
@@ -584,7 +597,19 @@
  *  This event message is issued when an actionpoint sample request is received
  *  with a message length that doesn't match the expected value.
  */
-#define LC_APSAMPLE_LEN_ERR_EID 42
+#define LC_APSAMPLE_LEN_ERR_EID 43
+
+/**
+ * \brief LC Actionpoint Sample All Message Length Invalid Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  This event message is issued when an actionpoint sample all request is received
+ *  with a message length that doesn't match the expected value.
+ */
+#define LC_APSAMPLE_ALL_LEN_ERR_EID 44
 
 /**
  * \brief LC Command Message Length Invalid Event ID
@@ -596,7 +621,7 @@
  *  This event message is issued when a ground command message is received
  *  with a message length that doesn't match the expected value.
  */
-#define LC_CMD_LEN_ERR_EID 43
+#define LC_CMD_LEN_ERR_EID 45
 
 /**
  * \brief LC Watchpoint Message Unsubscribe Failed Event ID
@@ -608,7 +633,7 @@
  *  This event message is issued when an error is encountered
  *  unsubscribing to a watchpoint message ID
  */
-#define LC_UNSUB_WP_ERR_EID 44
+#define LC_UNSUB_WP_ERR_EID 46
 
 /**
  * \brief LC Watchpoint Message Subscribe Failed Event ID
@@ -620,7 +645,7 @@
  *  This event message is issued when an error is encountered
  *  when subscribing to a watchpoint message iD
  */
-#define LC_SUB_WP_ERR_EID 45
+#define LC_SUB_WP_ERR_EID 47
 
 /**
  * \brief LC Watchpoint Results Table Not Saved To CDS On Exit Event ID
@@ -633,7 +658,7 @@
  *  table (WRT) data could not be saved to the CDS on application
  *  exit.
  */
-#define LC_WRT_NO_SAVE_ERR_EID 46
+#define LC_WRT_NO_SAVE_ERR_EID 48
 
 /**
  * \brief LC Actionpoint Results Table Not Saved To CDS On Exit Event ID
@@ -646,7 +671,7 @@
  *  table (ART) data could not be saved to the CDS on application
  *  exit.
  */
-#define LC_ART_NO_SAVE_ERR_EID 47
+#define LC_ART_NO_SAVE_ERR_EID 49
 
 /**
  * \brief LC Application Data Not Saved To CDS On Startup Event ID
@@ -658,7 +683,7 @@
  *  This event message is issued when the LC application data
  *  could not be saved to the CDS on application startup.
  */
-#define LC_APP_NO_SAVE_START_ERR_EID 48
+#define LC_APP_NO_SAVE_START_ERR_EID 50
 
 /**
  * \brief LC Unreferenced Message ID Received Event ID
@@ -671,7 +696,7 @@
  *  been received that isn't a recognized LC message and has no
  *  defined watchpoints referencing it's message ID
  */
-#define LC_MID_INF_EID 49
+#define LC_MID_INF_EID 51
 
 /**
  * \brief LC Watchpoint Data Type Undefined Event ID
@@ -683,7 +708,7 @@
  *  This event message is issued whenever an undefined watchpoint data type
  *  identifier is detected
  */
-#define LC_WP_DATATYPE_ERR_EID 50
+#define LC_WP_DATATYPE_ERR_EID 52
 
 /**
  * \brief LC Watchpoint Operator ID Invalid Event ID
@@ -695,7 +720,7 @@
  *  This event message is issued whenever an undefined watchpoint
  *  operator identifier is detected
  */
-#define LC_WP_OPERID_ERR_EID 51
+#define LC_WP_OPERID_ERR_EID 53
 
 /**
  * \brief LC Watchpoint Data Value Is Float NAN Event ID
@@ -708,7 +733,7 @@
  *  type, but the extracted value would equate to a floating point
  *  NAN (not-a-number) value
  */
-#define LC_WP_NAN_ERR_EID 52
+#define LC_WP_NAN_ERR_EID 54
 
 /**
  * \brief LC Watchpoint Offset Value Invalid Event ID
@@ -721,7 +746,7 @@
  *  the end of the message as reported by the #CFE_MSG_GetSize
  *  function
  */
-#define LC_WP_OFFSET_ERR_EID 53
+#define LC_WP_OFFSET_ERR_EID 55
 
 /**
  * \brief LC Watchpoint Definition Table Validation Floating Point Check Failed Event ID
@@ -736,7 +761,7 @@
  *  for a wachpoint definition is floating point and the comparison value
  *  equates to a floating point NAN (not-a-number) or infinite value.
  */
-#define LC_WDTVAL_FPERR_EID 54
+#define LC_WDTVAL_FPERR_EID 56
 
 /**
  * \brief LC Watchpoint Definition Table Validation Failed (Not Floating Point Check) Event ID
@@ -749,7 +774,7 @@
  *  fails for a watchpoint definition table (WDT) load and the error is
  *  NOT a failed floating point check.
  */
-#define LC_WDTVAL_ERR_EID 55
+#define LC_WDTVAL_ERR_EID 57
 
 /**
  * \brief LC Watchpoint Definition Table Validation Results Event ID
@@ -761,7 +786,7 @@
  *  This event message is issued when a table validation has been
  *  completed for a watchpoint definition table (WDT) load
  */
-#define LC_WDTVAL_INF_EID 56
+#define LC_WDTVAL_INF_EID 58
 
 /**
  * \brief LC Sample Actionpoint Current Actionpoint State Invalid Event ID
@@ -774,7 +799,7 @@
  *  has been received and the current state for the specified
  *  actionpoint state is either #LC_APSTATE_NOT_USED or #LC_APSTATE_PERMOFF.
  */
-#define LC_APSAMPLE_CURR_ERR_EID 57
+#define LC_APSAMPLE_CURR_ERR_EID 59
 
 /**
  * \brief LC Actionpoint State Change From PASS To FAIL Event ID
@@ -786,7 +811,7 @@
  *  This event message is issued when an actionpoint evaluation transitions
  *  from #LC_ACTION_PASS to #LC_ACTION_FAIL
  */
-#define LC_AP_PASSTOFAIL_INF_EID 58
+#define LC_AP_PASSTOFAIL_INF_EID 60
 
 /**
  * \brief LC Actionpoint Failed While Limit Checker State Passive Event ID
@@ -798,7 +823,7 @@
  *  This event message is issued when an actionpoint fails evaluation while
  *  the LC task operating state is #LC_STATE_PASSIVE
  */
-#define LC_PASSIVE_FAIL_DBG_EID 59
+#define LC_PASSIVE_FAIL_DBG_EID 61
 
 /**
  * \brief LC Actionpoint Failed While Actionpoint State Passive Event ID
@@ -810,7 +835,7 @@
  *  This event message is issued when an actionpoint fails evaluation while
  *  the actionpoint state is #LC_APSTATE_PASSIVE
  */
-#define LC_AP_PASSIVE_FAIL_INF_EID 60
+#define LC_AP_PASSIVE_FAIL_INF_EID 62
 
 /**
  * \brief LC Actionpoint State Change From FAIL To PASS Event ID
@@ -822,7 +847,7 @@
  *  This event message is issued when an actionpoint evaluation transitions
  *  from #LC_ACTION_FAIL to #LC_ACTION_PASS
  */
-#define LC_AP_FAILTOPASS_INF_EID 61
+#define LC_AP_FAILTOPASS_INF_EID 63
 
 /**
  * \brief LC Actionpoint Evaluated To Error Event ID
@@ -834,7 +859,7 @@
  *  This event message is issued when an actionpoint evaluation
  *  results in #LC_ACTION_ERROR
  */
-#define LC_ACTION_ERROR_ERR_EID 62
+#define LC_ACTION_ERROR_ERR_EID 64
 
 /**
  * \brief LC Actionpoint RPN Expression Illegal Event ID
@@ -846,7 +871,7 @@
  *  This event message is issued when an illegal Reverse Polish Notation
  *  (RPN) expression is detected during an actionpoint evaluation
  */
-#define LC_INVALID_RPN_ERR_EID 63
+#define LC_INVALID_RPN_ERR_EID 65
 
 /**
  * \brief LC Actionpoint Definition Table Validation RPN Equation Check Failed Event ID
@@ -859,7 +884,7 @@
  *  fails for an actionpoint definition table (ADT) load and the error is
  *  a failed RPN equation check.
  */
-#define LC_ADTVAL_RPNERR_EID 64
+#define LC_ADTVAL_RPNERR_EID 66
 
 /**
  * \brief LC Actionpoint Definition Table Validation Failed (Not RPN Equation Check) Event ID
@@ -872,7 +897,7 @@
  *  fails for an actioinpoint definition table (ADT) load and the error is
  *  NOT a failed RPN equation check.
  */
-#define LC_ADTVAL_ERR_EID 65
+#define LC_ADTVAL_ERR_EID 67
 
 /**
  * \brief LC Actionpoint Definition Table Validation Result Event ID
@@ -884,7 +909,7 @@
  *  This event message is issued when a table validation has been
  *  completed for an actionpoint definition table (ADT) load
  */
-#define LC_ADTVAL_INF_EID 66
+#define LC_ADTVAL_INF_EID 68
 
 /**
  * \brief LC LC_CustomFunction Called With Unexpected Watchpoint ID Event ID
@@ -897,7 +922,7 @@
  *  function #LC_CustomFunction is called with an unexpected
  *  watchpoint ID
  */
-#define LC_CFCALL_ERR_EID 67
+#define LC_CFCALL_ERR_EID 69
 
 /**
  * \brief LC Watchdog Definition Table Critical Table Registration Failed Event ID
@@ -909,7 +934,7 @@
  *  This event message is issued when the watchpoint definition
  *  table (WDT) could not be registered as a critical table.
  */
-#define LC_WDT_REGISTER_CRIT_ERR_EID 68
+#define LC_WDT_REGISTER_CRIT_ERR_EID 70
 
 /**
  * \brief LC Actionpoint Definition Table Critical Table Registration Failed Event ID
@@ -921,7 +946,7 @@
  *  This event message is issued when the actionpoint definition
  *  table (ADT) could not be registered as a critical table.
  */
-#define LC_ADT_REGISTER_CRIT_ERR_EID 69
+#define LC_ADT_REGISTER_CRIT_ERR_EID 71
 
 /**
  * \brief LC Actionpoint Definition Table Base ID

--- a/fsw/src/lc_app.c
+++ b/fsw/src/lc_app.c
@@ -317,6 +317,20 @@ CFE_Status_t LC_SbInit(void)
         }
     }
 
+    if (Status == CFE_SUCCESS)
+    {
+        /*
+        ** Subscribe to LC sample all actionpoints messages...
+        */
+        Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(LC_SAMPLE_AP_ALL_MID), LC_OperData.CmdPipe);
+        if (Status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(LC_SUB_SAMPLE_ALL_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Error Subscribing to Sample All CMD, MID=0x%08X, RC=0x%08X", LC_SAMPLE_AP_ALL_MID,
+                              (unsigned int)Status);
+        }
+    }
+
     return Status;
 }
 

--- a/fsw/src/lc_cmds.c
+++ b/fsw/src/lc_cmds.c
@@ -107,6 +107,25 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Sample All Actionpoints Request (no parameters)                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void LC_SampleAllAPsReq(const CFE_SB_Buffer_t *BufPtr)
+{
+    /*
+    ** Ignore AP sample requests if disabled at the application level
+    */
+    if (LC_AppData.CurrentLCState != LC_STATE_DISABLED)
+    {
+        /*
+        ** Sample all actionpoints (0 to LC_MAX_ACTIONPOINTS-1)
+        */
+        LC_SampleAPs(0, LC_MAX_ACTIONPOINTS - 1);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* Housekeeping request                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/lc_cmds.h
+++ b/fsw/src/lc_cmds.h
@@ -95,6 +95,20 @@ void LC_ResetResultsWP(uint32 StartIndex, uint32 EndIndex, bool ResetStatsCmd);
 void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr);
 
 /**
+ * \brief Sample all actionpoints request
+ *
+ *  \par Description
+ *       Processes an on-board sample all actionpoints request message.
+ *       This message has no parameters and samples all actionpoints.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       This message does not affect the command execution counter
+ *
+ *  \param[in] BufPtr Pointer to Software Bus buffer
+ */
+void LC_SampleAllAPsReq(const CFE_SB_Buffer_t *BufPtr);
+
+/**
  * \brief Housekeeping request
  *
  *  \par Description

--- a/fsw/src/lc_dispatch.c
+++ b/fsw/src/lc_dispatch.c
@@ -78,6 +78,16 @@ bool LC_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
                                   (int)ExpectedLength);
                 break;
 
+            case LC_SAMPLE_AP_ALL_MID:
+                /*
+                ** Same as LC_SAMPLE_AP_MID - don't increment error counter for internal messages
+                */
+                CFE_EVS_SendEvent(LC_APSAMPLE_ALL_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Invalid AP sample all msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
+                                  (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
+                                  (int)ExpectedLength);
+                break;
+
             default:
                 /*
                 ** All other cases, increment error counter
@@ -111,6 +121,24 @@ void LC_SampleAPVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     if (LC_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
         LC_SampleAPReq(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Sample All Actionpoints Request (no parameters)                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void LC_SampleAllAPsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(LC_SampleAllAPsCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (LC_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        LC_SampleAllAPsReq(BufPtr);
     }
 }
 
@@ -256,6 +284,13 @@ CFE_Status_t LC_AppPipe(const CFE_SB_Buffer_t *BufPtr)
         */
         case LC_SAMPLE_AP_MID:
             LC_SampleAPVerifyDispatch(BufPtr);
+            break;
+
+        /*
+        ** Sample all actionpoints request (no parameters)
+        */
+        case LC_SAMPLE_AP_ALL_MID:
+            LC_SampleAllAPsVerifyDispatch(BufPtr);
             break;
 
         /*

--- a/fsw/src/lc_dispatch.h
+++ b/fsw/src/lc_dispatch.h
@@ -42,8 +42,9 @@
  *       the message and command IDs and calls the appropriate routine
  *       to handle the message.
  *
- *       All messageIDs other than #LC_CMD_MID, #LC_SEND_HK_MID, and
- *       #LC_SAMPLE_AP_MID are assumed to be monitor packets.
+ *       All messageIDs other than #LC_CMD_MID, #LC_SEND_HK_MID,
+ *       #LC_SAMPLE_AP_MID, and #LC_SAMPLE_AP_ALL_MID are assumed
+ *       to be monitor packets.
  *
  *  \par Assumptions, External Events, and Notes:
  *       None

--- a/unit-test/lc_app_tests.c
+++ b/unit-test/lc_app_tests.c
@@ -499,6 +499,23 @@ void LC_SbInit_Test_SubscribeSampleCmdError(void)
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 }
 
+void LC_SbInit_Test_SubscribeSampleAllCmdError(void)
+{
+    CFE_Status_t Result;
+
+    /* Set to generate error message LC_SUB_SAMPLE_ALL_CMD_ERR_EID */
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 4, -1);
+
+    /* Execute the function being tested */
+    Result = LC_SbInit();
+
+    /* Verify results */
+    UtAssert_True(Result == -1, "Result == -1");
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
+}
+
 void LC_TableInit_Test_CreateResultsTablesError(void)
 {
     LC_OperData.HaveActiveCDS = true;
@@ -1477,6 +1494,8 @@ void UtTest_Setup(void)
                "LC_SbInit_Test_SubscribeGndCmdError");
     UtTest_Add(LC_SbInit_Test_SubscribeSampleCmdError, LC_Test_Setup, LC_Test_TearDown,
                "LC_SbInit_Test_SubscribeSampleCmdError");
+    UtTest_Add(LC_SbInit_Test_SubscribeSampleAllCmdError, LC_Test_Setup, LC_Test_TearDown,
+               "LC_SbInit_Test_SubscribeSampleAllCmdError");
 
     UtTest_Add(LC_TableInit_Test_CreateTaskCDSError, LC_Test_Setup, LC_Test_TearDown,
                "LC_TableInit_Test_CreateTaskCDSError");

--- a/unit-test/lc_cmds_tests.c
+++ b/unit-test/lc_cmds_tests.c
@@ -36,6 +36,7 @@
 #include "lc_version.h"
 #include "lc_test_utils.h"
 #include "lc_watch.h"
+#include "lc_action.h"
 
 /* UT includes */
 #include "uttest.h"
@@ -240,6 +241,36 @@ void LC_SampleAPReq_Test_SampleAllUpdateAgeZero(void)
     LC_SampleAPReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
+}
+
+void LC_SampleAllAPsReq_Test_StateEnabled(void)
+{
+    /* Set LC state to enabled */
+    LC_AppData.CurrentLCState = LC_STATE_ACTIVE;
+
+    /* Execute the function being tested */
+    LC_SampleAllAPsReq(&UT_CmdBuf.Buf);
+
+    /* Verify results - should have called LC_SampleAPs */
+    UtAssert_STUB_COUNT(LC_SampleAPs, 1);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
+}
+
+void LC_SampleAllAPsReq_Test_StateDisabled(void)
+{
+    /* Set LC state to disabled */
+    LC_AppData.CurrentLCState = LC_STATE_DISABLED;
+
+    /* Execute the function being tested */
+    LC_SampleAllAPsReq(&UT_CmdBuf.Buf);
+
+    /* Verify results - should NOT have called LC_SampleAPs */
+    UtAssert_STUB_COUNT(LC_SampleAPs, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
@@ -2168,6 +2199,11 @@ void UtTest_Setup(void)
                "LC_SampleAPReq_Test_SampleAllUpdateAgeZero");
     UtTest_Add(LC_SampleAPReq_Test_BadSampleAllArgs, LC_Test_Setup, LC_Test_TearDown,
                "LC_SampleAPReq_Test_BadSampleAllArgs");
+
+    UtTest_Add(LC_SampleAllAPsReq_Test_StateEnabled, LC_Test_Setup, LC_Test_TearDown,
+               "LC_SampleAllAPsReq_Test_StateEnabled");
+    UtTest_Add(LC_SampleAllAPsReq_Test_StateDisabled, LC_Test_Setup, LC_Test_TearDown,
+               "LC_SampleAllAPsReq_Test_StateDisabled");
 
     UtTest_Add(LC_SendHkCmd_Test_WatchStale, LC_Test_Setup, LC_Test_TearDown, "LC_SendHkCmd_Test_WatchStale");
     UtTest_Add(LC_SendHkCmd_Test_WatchFalse, LC_Test_Setup, LC_Test_TearDown, "LC_SendHkCmd_Test_WatchFalse");

--- a/unit-test/lc_dispatch_tests.c
+++ b/unit-test/lc_dispatch_tests.c
@@ -88,6 +88,29 @@ void LC_AppPipe_Test_SampleAPRequest(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
+void LC_AppPipe_Test_SampleAPAllRequest(void)
+{
+    CFE_SB_MsgId_t TestMsgId;
+
+    TestMsgId = CFE_SB_ValueToMsgId(LC_SAMPLE_AP_ALL_MID);
+
+    LC_Dispatch_Test_SetupMsg(TestMsgId, 0, sizeof(LC_SampleAllAPsCmd_t));
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(LC_AppPipe(&UT_CmdBuf.Buf), CFE_SUCCESS);
+    UtAssert_STUB_COUNT(LC_SampleAllAPsReq, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* Bad Length */
+    LC_Dispatch_Test_SetupMsg(TestMsgId, 0, sizeof(LC_SampleAllAPsCmd_t) + 1);
+    UtAssert_INT32_EQ(LC_AppPipe(&UT_CmdBuf.Buf), CFE_SUCCESS);
+    /* Verify handler NOT called again */
+    UtAssert_STUB_COUNT(LC_SampleAllAPsReq, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, LC_APSAMPLE_ALL_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
 void LC_AppPipe_Test_SendHkCmd(void)
 {
     CFE_SB_MsgId_t TestMsgId;
@@ -316,6 +339,7 @@ void LC_AppPipe_Test_MonitorPacket(void)
 void UtTest_Setup(void)
 {
     UtTest_Add(LC_AppPipe_Test_SampleAPRequest, LC_Test_Setup, LC_Test_TearDown, "LC_AppPipe_Test_SampleAPRequest");
+    UtTest_Add(LC_AppPipe_Test_SampleAPAllRequest, LC_Test_Setup, LC_Test_TearDown, "LC_AppPipe_Test_SampleAPAllRequest");
     UtTest_Add(LC_AppPipe_Test_SendHkCmd, LC_Test_Setup, LC_Test_TearDown, "LC_AppPipe_Test_SendHkCmd");
     UtTest_Add(LC_AppPipe_Test_Noop, LC_Test_Setup, LC_Test_TearDown, "LC_AppPipe_Test_Noop");
     UtTest_Add(LC_AppPipe_Test_Reset, LC_Test_Setup, LC_Test_TearDown, "LC_AppPipe_Test_Reset");

--- a/unit-test/stubs/lc_cmds_stubs.c
+++ b/unit-test/stubs/lc_cmds_stubs.c
@@ -127,6 +127,18 @@ void LC_SampleAPReq(const CFE_SB_Buffer_t *BufPtr)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for LC_SampleAllAPsReq()
+ * ----------------------------------------------------
+ */
+void LC_SampleAllAPsReq(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(LC_SampleAllAPsReq, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(LC_SampleAllAPsReq, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for LC_SendHkCmd()
  * ----------------------------------------------------
  */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #76 
  - adds a simple command to sample all action points - this way is more clear than the opaque version of having to add specific parameters to the `LC_SAMPLE_AP_MID` command

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).  
100% coverage is maintained with the new tests that are included.

**Expected behavior changes**
No change to existing behavior other than the new command that is now available.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt