### PR TITLE
Fix #133, Add math library dependency to LC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 project(CFS_LC C)
 
+include(CheckSymbolExists)
+
+# Check for "isnan" and "isfinite" is present in "math.h"
+set(CMAKE_REQUIRED_LIBRARIES m)
+check_symbol_exists(isnan "math.h" HAVE_ISNAN CMAKE_REQUIRED_LIBRARIES)
+check_symbol_exists(isfinite "math.h" HAVE_ISFINITE CMAKE_REQUIRED_LIBRARIES)
+
+if (HAVE_ISNAN OR HAVE_ISFINITE)
+  # Add math library dependency to LC App
+  message(STATUS "Adding math library dependency to LC App...")
+  link_libraries(m)
+endif()
+
 set(APP_SRC_FILES
   fsw/src/lc_custom.c
   fsw/src/lc_app.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,5 @@
 project(CFS_LC C)
 
-include(CheckSourceCompiles)
-
-# Determine if math library required for "isnan" and "isfinite"
-check_source_compiles(
-  C
-  "#include <float.h>
-   #include <math.h>  
-   int main()
-   {
-     float FloatValue = 1.1f;
-     if (isnan(FloatValue) || !isfinite(FloatValue))
-        return 1;
-     else
-        return 0;
-  }"
-  HAS_MATH_LIB
-)
-
-# Add math library dependency if test code failed to compile and link
-if (NOT HAS_MATH_LIB)
-  message(STATUS "Adding math library dependency to lc app")
-  link_libraries(m)
-endif()
-
 set(APP_SRC_FILES
   fsw/src/lc_custom.c
   fsw/src/lc_app.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,29 @@
 project(CFS_LC C)
 
+include(CheckSourceCompiles)
+
+# Determine if math library required for "isnan" and "isfinite"
+check_source_compiles(
+  C
+  "#include <float.h>
+   #include <math.h>  
+   int main()
+   {
+     float FloatValue = 1.1f;
+     if (isnan(FloatValue) || !isfinite(FloatValue))
+        return 1;
+     else
+        return 0;
+  }"
+  HAS_MATH_LIB
+)
+
+# Add math library dependency if test code failed to compile and link
+if (NOT HAS_MATH_LIB)
+  message(STATUS "Adding math library dependency to lc app")
+  link_libraries(m)
+endif()
+
 set(APP_SRC_FILES
   fsw/src/lc_custom.c
   fsw/src/lc_app.c

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -7,6 +7,9 @@
 #
 ##################################################################
 
+# Determine if math library is present
+find_library(MATH_LIB_FOUND NAMES m)
+
 add_cfe_coverage_stubs("lc_internal"
   utilities/lc_test_utils.c
   stubs/lc_app_stubs.c
@@ -20,7 +23,7 @@ add_cfe_coverage_stubs("lc_internal"
 )
 
 # Link with the cfe core stubs and unit test assert libs
-if (QNX_SDP_VERSION)
+if (MATH_LIB_FOUND)
   target_link_libraries(coverage-lc_internal-stubs ut_core_api_stubs ut_assert m)
 else()
   target_link_libraries(coverage-lc_internal-stubs ut_core_api_stubs ut_assert)

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -20,7 +20,11 @@ add_cfe_coverage_stubs("lc_internal"
 )
 
 # Link with the cfe core stubs and unit test assert libs
-target_link_libraries(coverage-lc_internal-stubs ut_core_api_stubs ut_assert)
+if (QNX_SDP_VERSION)
+  target_link_libraries(coverage-lc_internal-stubs ut_core_api_stubs ut_assert m)
+else()
+  target_link_libraries(coverage-lc_internal-stubs ut_core_api_stubs ut_assert)
+endif()
 
 # Include and expose unit test utilities, fsw/inc, and fsw/src includes
 target_include_directories(coverage-lc_internal-stubs PUBLIC utilities)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Fixes #133 by adding the math library dependency to the LC App including unit and coverage tests.

**Testing performed**
Steps taken to test the contribution:
1. Linux Build steps
    - make native_std.distclean
    - make native_std.prep
    - make native_std.install
    - make native_std.runtest
2. QNX Build steps
    - make aarch64le_qnx_gnu.distclean
    - make aarch64le_qnx_gnu.prep
    - make aarch64le_qnx_gnu.install 
3. Linux Execution steps
    - cd build-native_std/exe/cpu1/
    - ./core-cpu1
    -  Verify cFS boots and LC App loads and executes 
4. QNX Execution steps
    - Build QNX IFS Image including cFS
    - Boot QNX IFS Image on Raspberry Pi 4 via U-boot and TFTP 
    - cd /temp/cfs/cpu1/
    - ./core-cpu1
    -  Verify cFS boots and LC App loads and executes 

**Expected behavior changes**

No impact to behavior

**System(s) tested on**
 - Hardware: PC/VM, Raspberry Pi 4
 - OS: RHEL 9, QNX 8.x

**Additional context**

N/A

**Third party code**

N/A

**Contributor Info - All information REQUIRED for consideration of pull request**

Dwaine Molock, NASA/GSFC, Code 534